### PR TITLE
Document installation and SDL backend dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,142 @@ import uirelays/[coords, screen, input, backend]
 initBackend()
 ```
 
+## Installation
+
+Install this package with Nimble:
+
+```sh
+nimble install
+```
+
+Backend selection:
+
+- Default on Windows: WinAPI
+- Default on macOS: Cocoa
+- Default on Linux/BSD: X11
+- Optional overrides: `-d:gtk4`, `-d:sdl3`, `-d:sdl2`
+
+### Nim Packages For SDL Backends
+
+The SDL backends need extra Nim packages in addition to the native system
+libraries:
+
+```sh
+nimble install https://github.com/nim-lang/sdl3
+nimble install https://github.com/nim-lang/sdl2
+```
+
+Install `sdl3` when building with `-d:sdl3`. Install `sdl2` when building
+with `-d:sdl2`.
+
+### Linux
+
+Choose the backend you want and install its native development packages.
+
+#### Ubuntu
+
+Default X11 backend:
+
+```sh
+sudo apt install libx11-dev libxft-dev
+```
+
+GTK4 backend:
+
+```sh
+sudo apt install libgtk-4-dev libpango1.0-dev libcairo2-dev libfontconfig1-dev libglib2.0-dev pkg-config
+```
+
+SDL3 backend:
+
+```sh
+sudo apt install libsdl3-dev libsdl3-ttf-dev
+nimble install https://github.com/nim-lang/sdl3
+```
+
+SDL2 backend:
+
+```sh
+sudo apt install libsdl2-dev libsdl2-ttf-dev
+nimble install https://github.com/nim-lang/sdl2
+```
+
+#### Fedora
+
+Default X11 backend:
+
+```sh
+sudo dnf install libX11-devel libXft-devel
+```
+
+GTK4 backend:
+
+```sh
+sudo dnf install gtk4-devel pango-devel cairo-devel fontconfig-devel glib2-devel pkgconf-pkg-config
+```
+
+SDL3 backend:
+
+```sh
+sudo dnf install SDL3-devel SDL3_ttf-devel
+nimble install https://github.com/nim-lang/sdl3
+```
+
+SDL2 backend:
+
+```sh
+sudo dnf install SDL2-devel SDL2_ttf-devel
+nimble install https://github.com/nim-lang/sdl2
+```
+
+### macOS
+
+The default Cocoa backend needs no extra native libraries.
+
+```sh
+nim c examples/hello.nim
+```
+
+For SDL backends on macOS, install the SDL libraries with your preferred
+package manager, then install the matching Nim package:
+
+```sh
+nimble install https://github.com/nim-lang/sdl3
+nimble install https://github.com/nim-lang/sdl2
+```
+
+### Windows
+
+The default WinAPI backend needs no extra native libraries.
+
+```sh
+nim c examples/hello.nim
+```
+
+For SDL backends on Windows, install the SDL native libraries separately
+and then install the matching Nim package:
+
+```sh
+nimble install https://github.com/nim-lang/sdl3
+nimble install https://github.com/nim-lang/sdl2
+```
+
+### Build Examples
+
+Use the default backend for your platform:
+
+```sh
+nim c examples/hello.nim
+```
+
+Force a specific backend:
+
+```sh
+nim c -d:gtk4 examples/hello.nim
+nim c -d:sdl3 examples/hello.nim
+nim c -d:sdl2 examples/hello.nim
+```
+
 ## Examples
 
 - [hello.nim](examples/hello.nim) -- Uses `import uirelays` for maximum convenience

--- a/uirelays.nimble
+++ b/uirelays.nimble
@@ -10,3 +10,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 2.0.0"
+requires "sdl3"
+
+requires "https://github.com/nim-lang/sdl3"
+

--- a/uirelays.nimble
+++ b/uirelays.nimble
@@ -10,7 +10,3 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 2.0.0"
-requires "sdl3"
-
-requires "https://github.com/nim-lang/sdl3"
-


### PR DESCRIPTION
  ## Summary

  Add installation documentation for supported platforms and backends, including Linux distro package commands and the Nim packages needed for SDL2 and SDL3 backends.

  ## Changes

  - document default backend selection by platform
  - document backend override flags
  - add Ubuntu and Fedora package installation commands for:
    - X11
    - GTK4
    - SDL2
    - SDL3
  - document required Nim packages for SDL backends:
    - `https://github.com/nim-lang/sdl3`
    - `https://github.com/nim-lang/sdl2`
  - add example build commands
  - update `uirelays.nimble` backend dependency declaration accordingly

  ## Why

  The repo supported multiple backends, but the installation story was implicit and platform-specific setup was not documented in one place. This PR makes backend setup
  explicit and makes the SDL Nim dependencies discoverable.