### PR TITLE
Optimize SDL3 backend text rendering and resource lifetime

### DIFF
--- a/src/uirelays/drivers/sdl3_driver.nim
+++ b/src/uirelays/drivers/sdl3_driver.nim
@@ -2,7 +2,7 @@
 
 import sdl3
 import sdl3_ttf
-import std/os
+import std/[hashes, os, tables]
 import ../coords, ../input, ../screen
 
 # --- Font handle management ---
@@ -12,7 +12,42 @@ type
     ttfFont: sdl3_ttf.Font
     metrics: FontMetrics
 
+  MeasureCacheKey = object
+    fontId: int
+    text: string
+
+  TextCacheKey = object
+    fontId: int
+    fg: screen.Color
+    text: string
+
+  TextCacheEntry = object
+    texture: sdl3.Texture
+    extent: TextExtent
+
 var fonts: seq[FontSlot]
+
+proc `==`(a, b: MeasureCacheKey): bool {.inline.} =
+  a.fontId == b.fontId and a.text == b.text
+
+proc hash(x: MeasureCacheKey): Hash {.inline.} =
+  var h: Hash = 0
+  h = h !& hash(x.fontId)
+  h = h !& hash(x.text)
+  !$h
+
+proc `==`(a, b: TextCacheKey): bool {.inline.} =
+  a.fontId == b.fontId and a.fg == b.fg and a.text == b.text
+
+proc hash(x: TextCacheKey): Hash {.inline.} =
+  var h: Hash = 0
+  h = h !& hash(x.fontId)
+  h = h !& hash(x.fg.r)
+  h = h !& hash(x.fg.g)
+  h = h !& hash(x.fg.b)
+  h = h !& hash(x.fg.a)
+  h = h !& hash(x.text)
+  !$h
 
 proc toColor(c: screen.Color): sdl3.Color {.inline.} =
   sdl3.Color(r: c.r, g: c.g, b: c.b, a: c.a)
@@ -27,12 +62,54 @@ proc getFontPtr(f: screen.Font): sdl3_ttf.Font {.inline.} =
 var
   win: sdl3.Window
   ren: sdl3.Renderer
+  defaultFontPath: string
+  didResolveDefaultFontPath: bool
+  measureCache: Table[MeasureCacheKey, TextExtent]
+  textCache: Table[TextCacheKey, TextCacheEntry]
+  cursors: array[CursorKind, sdl3.Cursor]
+  currentCursor = curDefault
+
+proc clearMeasureCache() =
+  measureCache.clear()
+
+proc clearTextCache() =
+  for entry in textCache.values:
+    if entry.texture != nil:
+      destroyTexture(entry.texture)
+  textCache.clear()
+
+proc clearCursorCache() =
+  for cursor in mitems(cursors):
+    if cursor != nil:
+      destroyCursor(cursor)
+      cursor = nil
+  currentCursor = curDefault
+
+proc closeAllFonts() =
+  for slot in mitems(fonts):
+    if slot.ttfFont != nil:
+      sdl3_ttf.closeFont(slot.ttfFont)
+      slot.ttfFont = nil
+  fonts.setLen(0)
+
+proc resetSdlState() =
+  clearTextCache()
+  clearMeasureCache()
+  clearCursorCache()
+  closeAllFonts()
+  if ren != nil:
+    destroyRenderer(ren)
+    ren = nil
+  if win != nil:
+    destroyWindow(win)
+    win = nil
 
 # --- Screen hook implementations ---
 
-proc resolveFontPath(path: string): string =
-  if path.len > 0:
-    return path
+proc resolveDefaultFontPath(): string =
+  if didResolveDefaultFontPath:
+    return defaultFontPath
+  didResolveDefaultFontPath = true
 
   when defined(windows):
     let candidates = [
@@ -56,11 +133,20 @@ proc resolveFontPath(path: string): string =
 
   for candidate in candidates:
     if fileExists(candidate):
-      return candidate
+      defaultFontPath = candidate
+      return defaultFontPath
 
-  ""
+  defaultFontPath = ""
+  defaultFontPath
+
+proc resolveFontPath(path: string): string =
+  if path.len > 0:
+    return path
+  resolveDefaultFontPath()
 
 proc sdlCreateWindow(layout: var ScreenLayout) =
+  if ren != nil or win != nil:
+    resetSdlState()
   discard createWindowAndRenderer(cstring"NimEdit",
     layout.width.cint, layout.height.cint, WINDOW_RESIZABLE, win, ren)
   discard startTextInput(win)
@@ -93,6 +179,8 @@ proc sdlOpenFont(path: string; size: int;
   metrics.descent = sdl3_ttf.getFontDescent(f)
   metrics.lineHeight = sdl3_ttf.getFontLineSkip(f)
   fonts.add FontSlot(ttfFont: f, metrics: metrics)
+  clearMeasureCache()
+  clearTextCache()
   result = screen.Font(fonts.len)
 
 proc sdlCloseFont(f: screen.Font) =
@@ -100,39 +188,60 @@ proc sdlCloseFont(f: screen.Font) =
   if idx >= 0 and idx < fonts.len and fonts[idx].ttfFont != nil:
     sdl3_ttf.closeFont(fonts[idx].ttfFont)
     fonts[idx].ttfFont = nil
+    clearMeasureCache()
+    clearTextCache()
+
+proc getCachedExtent(f: screen.Font; text: string): TextExtent =
+  let fp = getFontPtr(f)
+  if fp == nil or text.len == 0:
+    return TextExtent()
+  let key = MeasureCacheKey(fontId: f.int, text: text)
+  if key in measureCache:
+    return measureCache[key]
+  var w, h: cint
+  discard sdl3_ttf.getStringSize(fp, cstring(text), 0, w, h)
+  result = TextExtent(w: w, h: h)
+  measureCache[key] = result
 
 proc sdlMeasureText(f: screen.Font; text: string): TextExtent =
-  let fp = getFontPtr(f)
-  if fp != nil and text != "":
-    var w, h: cint
-    discard sdl3_ttf.getStringSize(fp, cstring(text), 0, w, h)
-    result = TextExtent(w: w, h: h)
+  getCachedExtent(f, text)
 
-proc sdlDrawText(f: screen.Font; x, y: int; text: string;
-                 fg, bg: screen.Color): TextExtent =
+proc getCachedTextEntry(f: screen.Font; text: string;
+                        fg: screen.Color): TextCacheEntry =
   let fp = getFontPtr(f)
-  if fp == nil or text == "": return
-  # Fill background, then draw blended text on top
-  let ext0 = sdlMeasureText(f, text)
-  var bgRect = FRect(x: x.cfloat, y: y.cfloat,
-                     w: ext0.w.cfloat, h: ext0.h.cfloat)
-  discard setRenderDrawColor(ren, bg.r, bg.g, bg.b, bg.a)
-  discard renderFillRect(ren, addr bgRect)
+  if fp == nil or text.len == 0 or ren == nil:
+    return TextCacheEntry()
+  let key = TextCacheKey(fontId: f.int, fg: fg, text: text)
+  if key in textCache:
+    return textCache[key]
   let surf = sdl3_ttf.renderTextBlended(fp, cstring(text), 0, toColor(fg))
-  if surf == nil: return
+  if surf == nil:
+    return TextCacheEntry()
   let tex = createTextureFromSurface(ren, surf)
   if tex == nil:
     destroySurface(surf)
-    return
+    return TextCacheEntry()
   discard setTextureBlendMode(tex, BLENDMODE_BLEND)
-  var tw, th: cfloat
-  discard getTextureSize(tex, tw, th)
-  var src = FRect(x: 0, y: 0, w: tw, h: th)
-  var dst = FRect(x: x.cfloat, y: y.cfloat, w: tw, h: th)
-  discard renderTexture(ren, tex, addr src, addr dst)
-  result = TextExtent(w: tw.int, h: th.int)
+  let entry = TextCacheEntry(texture: tex, extent: getCachedExtent(f, text))
   destroySurface(surf)
-  destroyTexture(tex)
+  textCache[key] = entry
+  entry
+
+proc sdlDrawText(f: screen.Font; x, y: int; text: string;
+                 fg, bg: screen.Color): TextExtent =
+  let entry = getCachedTextEntry(f, text, fg)
+  if entry.texture == nil:
+    return
+  # Fill background, then draw blended text on top
+  var bgRect = FRect(x: x.cfloat, y: y.cfloat,
+                     w: entry.extent.w.cfloat, h: entry.extent.h.cfloat)
+  discard setRenderDrawColor(ren, bg.r, bg.g, bg.b, bg.a)
+  discard renderFillRect(ren, addr bgRect)
+  var src = FRect(x: 0, y: 0, w: entry.extent.w.cfloat, h: entry.extent.h.cfloat)
+  var dst = FRect(x: x.cfloat, y: y.cfloat,
+                  w: entry.extent.w.cfloat, h: entry.extent.h.cfloat)
+  discard renderTexture(ren, entry.texture, addr src, addr dst)
+  result = entry.extent
 
 proc sdlGetFontMetrics(f: screen.Font): FontMetrics =
   let idx = f.int - 1
@@ -154,16 +263,22 @@ proc sdlDrawPoint(x, y: int; color: screen.Color) =
   discard renderPoint(ren, x.cfloat, y.cfloat)
 
 proc sdlSetCursor(c: CursorKind) =
-  let sc = case c
-    of curDefault, curArrow: SYSTEM_CURSOR_DEFAULT
-    of curIbeam: SYSTEM_CURSOR_TEXT
-    of curWait: SYSTEM_CURSOR_WAIT
-    of curCrosshair: SYSTEM_CURSOR_CROSSHAIR
-    of curHand: SYSTEM_CURSOR_POINTER
-    of curSizeNS: SYSTEM_CURSOR_NS_RESIZE
-    of curSizeWE: SYSTEM_CURSOR_EW_RESIZE
-  let cur = sdl3.createSystemCursor(sc)
-  discard sdl3.setCursor(cur)
+  if cursors[c] == nil:
+    let sc = case c
+      of curDefault, curArrow: SYSTEM_CURSOR_DEFAULT
+      of curIbeam: SYSTEM_CURSOR_TEXT
+      of curWait: SYSTEM_CURSOR_WAIT
+      of curCrosshair: SYSTEM_CURSOR_CROSSHAIR
+      of curHand: SYSTEM_CURSOR_POINTER
+      of curSizeNS: SYSTEM_CURSOR_NS_RESIZE
+      of curSizeWE: SYSTEM_CURSOR_EW_RESIZE
+    cursors[c] = sdl3.createSystemCursor(sc)
+  if cursors[c] == nil:
+    return
+  if c == currentCursor:
+    return
+  discard sdl3.setCursor(cursors[c])
+  currentCursor = c
 
 proc sdlSetWindowTitle(title: string) =
   if win != nil:
@@ -173,8 +288,11 @@ proc sdlSetWindowTitle(title: string) =
 
 proc sdlGetClipboardText(): string =
   let t = sdl3.getClipboardText()
-  if t != nil: result = $t
-  else: result = ""
+  if t != nil:
+    result = $t
+    sdlFree(t)
+  else:
+    result = ""
 
 proc sdlPutClipboardText(text: string) =
   discard setClipboardText(cstring(text))
@@ -333,7 +451,12 @@ proc sdlWaitEvent(e: var input.Event; timeoutMs: int;
 
 proc sdlGetTicks(): int = sdl3.getTicks().int
 proc sdlDelay(ms: int) = sdl3.delay(ms.uint32)
-proc sdlQuitRequest() = sdl3.quit()
+proc sdlQuitRequest() =
+  if win != nil:
+    discard stopTextInput(win)
+  resetSdlState()
+  sdl3_ttf.quit()
+  sdl3.quit()
 
 # --- Init ---
 

--- a/src/uirelays/drivers/sdl3_driver.nim
+++ b/src/uirelays/drivers/sdl3_driver.nim
@@ -2,6 +2,7 @@
 
 import sdl3
 import sdl3_ttf
+import std/os
 import ../coords, ../input, ../screen
 
 # --- Font handle management ---
@@ -29,6 +30,36 @@ var
 
 # --- Screen hook implementations ---
 
+proc resolveFontPath(path: string): string =
+  if path.len > 0:
+    return path
+
+  when defined(windows):
+    let candidates = [
+      r"C:\Windows\Fonts\segoeui.ttf",
+      r"C:\Windows\Fonts\arial.ttf"
+    ]
+  elif defined(macosx):
+    let candidates = [
+      "/System/Library/Fonts/SFNS.ttf",
+      "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
+      "/System/Library/Fonts/Supplemental/Arial.ttf"
+    ]
+  else:
+    let candidates = [
+      "/usr/share/fonts/google-noto-vf/NotoSans[wght].ttf",
+      "/usr/share/fonts/liberation-sans-fonts/LiberationSans-Regular.ttf",
+      "/usr/share/fonts/abattis-cantarell-vf-fonts/Cantarell-VF.otf",
+      "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+      "/usr/share/fonts/TTF/DejaVuSans.ttf"
+    ]
+
+  for candidate in candidates:
+    if fileExists(candidate):
+      return candidate
+
+  ""
+
 proc sdlCreateWindow(layout: var ScreenLayout) =
   discard createWindowAndRenderer(cstring"NimEdit",
     layout.width.cint, layout.height.cint, WINDOW_RESIZABLE, win, ren)
@@ -52,7 +83,10 @@ proc sdlSetClipRect(r: coords.Rect) =
 
 proc sdlOpenFont(path: string; size: int;
                  metrics: var FontMetrics): screen.Font =
-  let f = sdl3_ttf.openFont(cstring(path), size.cfloat)
+  let resolvedPath = resolveFontPath(path)
+  if resolvedPath.len == 0:
+    return screen.Font(0)
+  let f = sdl3_ttf.openFont(cstring(resolvedPath), size.cfloat)
   if f == nil: return screen.Font(0)
   sdl3_ttf.setFontHinting(f, sdl3_ttf.hintingLightSubpixel)
   metrics.ascent = sdl3_ttf.getFontAscent(f)


### PR DESCRIPTION
  ## Summary

  Reduce per-frame overhead in the SDL3 backend by caching text work and cleaning up SDL resources explicitly.

  ## Changes

  - cache text extents instead of repeatedly calling `TTF_GetStringSize`
  - cache rendered text textures instead of recreating/destroying them on every `drawText`
  - reuse system cursors instead of allocating a new cursor for each cursor change
  - free clipboard text returned by SDL
  - explicitly clean up cached textures, cursors, fonts, renderer, window, and `SDL_ttf` state on shutdown

  ## Why

  The old SDL3 text path did all of this for every text draw:
  - measure text
  - rasterize text
  - create a texture from the surface
  - render the texture
  - destroy the surface
  - destroy the texture

  That made text-heavy UIs much more expensive than they needed to be.

  ## Validation

  Measured with `examples/todo.nim` in `-d:release` under Callgrind using `SDL_VIDEODRIVER=dummy` for the same 3-second run.

  Top-line result:
  - total instructions: `182,215,094` -> `115,273,368`
  - reduction: `36.7%`

  Representative hotspot reductions:
  - `SDL_CreateTextureFromSurface`: `574 calls / 27,142,926 Ir` -> `7 calls / 354,083 Ir`
  - `TTF_GetStringSize`: `902 calls / 12,674,026 Ir` -> `7 calls / 304,414 Ir`
  - `TTF_RenderText_Blended`: `574 calls` -> `7 calls`

  Throughput in the same wall-clock run also increased:
  - `sdlDrawText` calls: `574` -> `875`
