### PR TITLE
Add explicit HiDPI window metrics support

### DIFF
--- a/doc/drivers.md
+++ b/doc/drivers.md
@@ -34,7 +34,8 @@ will compile and run -- it just won't do anything for the missing parts.
 
 | Field | Signature | Notes |
 |-------|-----------|-------|
-| `createWindow` | `proc (layout: var ScreenLayout)` | Create and show the window. Read `layout.width/height` for the requested size, write back the actual size. |
+| `createWindow` | `proc (layout: var ScreenLayout)` | Create and show the window. Read `layout.width/height` for the requested size, write back the actual logical size plus the current `scaleX/scaleY`. |
+| `getWindowLayout` | `proc (): ScreenLayout` | Return the current logical window size and current scale factors. Use this after resize or monitor changes if scale can change at runtime. |
 | `refresh` | `proc ()` | Present the current frame. For double-buffered drivers this means copying the back buffer to the window. |
 | `saveState` | `proc ()` | Push the current graphics state (clip rect). |
 | `restoreState` | `proc ()` | Pop the graphics state. |
@@ -112,7 +113,9 @@ into `Event` values. Key points:
   set `e.button` and `e.clicks` (track double/triple clicks yourself).
 - **Scroll**: `MouseWheelEvent` with `e.y` as the scroll direction
   (+1 up, -1 down).
-- **Window**: Emit `WindowResizeEvent` with the new size in `e.x`, `e.y`.
+- **Window**: Emit `WindowMetricsEvent` with the new logical size in `e.x`, `e.y`
+  and the current scale in `e.scaleX`, `e.scaleY`. `WindowResizeEvent` remains
+  available for older drivers but should be treated as legacy.
   Emit `WindowCloseEvent` when the user clicks the close button (don't
   destroy the window -- let the app decide). Emit `QuitEvent` for
   platform quit signals.

--- a/examples/editor.nim
+++ b/examples/editor.nim
@@ -278,7 +278,7 @@ proc main =
     case e.kind
     of QuitEvent, WindowCloseEvent:
       running = false
-    of WindowResizeEvent:
+    of WindowResizeEvent, WindowMetricsEvent:
       width = e.x
       height = e.y
     of MouseDownEvent:

--- a/examples/hello.nim
+++ b/examples/hello.nim
@@ -29,7 +29,7 @@ proc main =
       case e.kind
       of QuitEvent, WindowCloseEvent:
         running = false
-      of WindowResizeEvent:
+      of WindowResizeEvent, WindowMetricsEvent:
         width = e.x
         height = e.y
       of MouseDownEvent:

--- a/examples/layout_demo.nim
+++ b/examples/layout_demo.nim
@@ -44,7 +44,7 @@ proc main =
       case e.kind
       of QuitEvent, WindowCloseEvent:
         running = false
-      of WindowResizeEvent:
+      of WindowResizeEvent, WindowMetricsEvent:
         width = e.x
         height = e.y
       of MouseMoveEvent:

--- a/examples/paint.nim
+++ b/examples/paint.nim
@@ -42,7 +42,7 @@ proc main =
       case e.kind
       of QuitEvent, WindowCloseEvent:
         running = false
-      of WindowResizeEvent:
+      of WindowResizeEvent, WindowMetricsEvent:
         width = e.x; height = e.y
       of KeyDownEvent:
         if e.key == KeyEsc: running = false

--- a/examples/todo.nim
+++ b/examples/todo.nim
@@ -233,7 +233,7 @@ proc main =
       case e.kind
       of QuitEvent, WindowCloseEvent:
         running = false
-      of WindowResizeEvent:
+      of WindowResizeEvent, WindowMetricsEvent:
         width = e.x
         height = e.y
       of MouseMoveEvent:

--- a/src/uirelays/drivers/cocoa_backend.m
+++ b/src/uirelays/drivers/cocoa_backend.m
@@ -827,7 +827,7 @@ static NimEditView *mainView = nil;
 static NimEditWindowDelegate *winDelegate = nil;
 
 void cocoa_createWindow(int w, int h, int *outW, int *outH,
-                        int *outScaleX, int *outScaleY) {
+                        double *outScaleX, double *outScaleY) {
   @autoreleasepool {
     /* Initialize timing */
     mach_timebase_info(&timebaseInfo);
@@ -885,8 +885,26 @@ void cocoa_createWindow(int w, int h, int *outW, int *outH,
 
     *outW = (int)contentFrame.size.width;
     *outH = (int)contentFrame.size.height;
-    *outScaleX = (int)scale;
-    *outScaleY = (int)scale;
+    *outScaleX = (double)scale;
+    *outScaleY = (double)scale;
+  }
+}
+
+void cocoa_getWindowLayout(int *outW, int *outH, double *outScaleX, double *outScaleY) {
+  @autoreleasepool {
+    if (!mainWindow || !mainView) {
+      *outW = 0;
+      *outH = 0;
+      *outScaleX = 1.0;
+      *outScaleY = 1.0;
+      return;
+    }
+    NSRect contentFrame = [mainView frame];
+    CGFloat scale = [mainWindow backingScaleFactor];
+    *outW = (int)contentFrame.size.width;
+    *outH = (int)contentFrame.size.height;
+    *outScaleX = (double)scale;
+    *outScaleY = (double)scale;
   }
 }
 

--- a/src/uirelays/drivers/cocoa_driver.nim
+++ b/src/uirelays/drivers/cocoa_driver.nim
@@ -60,8 +60,10 @@ const
   neModAlt = 4.cint
   neModGui = 8.cint
 
-proc cCreateWindow(w, h: cint; outW, outH, outScaleX, outScaleY: ptr cint)
+proc cCreateWindow(w, h: cint; outW, outH: ptr cint; outScaleX, outScaleY: ptr cdouble)
   {.importc: "cocoa_createWindow", cdecl.}
+proc cGetWindowLayout(outW, outH: ptr cint; outScaleX, outScaleY: ptr cdouble)
+  {.importc: "cocoa_getWindowLayout", cdecl.}
 proc cRefresh() {.importc: "cocoa_refresh", cdecl.}
 proc cPollEvent(ev: ptr NEEvent): cint {.importc: "cocoa_pollEvent", cdecl.}
 proc cWaitEvent(ev: ptr NEEvent; timeoutMs: cint): cint {.importc: "cocoa_waitEvent", cdecl.}
@@ -100,13 +102,24 @@ proc cShutdown() {.importc: "cocoa_shutdown", cdecl.}
 # --- Relay implementations ---
 
 proc cocoaCreateWindow(layout: var ScreenLayout) =
-  var w, h, sx, sy: cint
+  var w, h: cint
+  var sx, sy: cdouble
   cCreateWindow(layout.width.cint, layout.height.cint,
                 addr w, addr h, addr sx, addr sy)
   layout.width = w
   layout.height = h
-  layout.scaleX = sx
-  layout.scaleY = sy
+  layout.scaleX = float32(sx)
+  layout.scaleY = float32(sy)
+
+proc cocoaGetWindowLayout(): ScreenLayout =
+  var w, h: cint
+  var sx, sy: cdouble
+  cGetWindowLayout(addr w, addr h, addr sx, addr sy)
+  ScreenLayout(
+    width: w,
+    height: h,
+    scaleX: float32(sx),
+    scaleY: float32(sy))
 
 proc cocoaRefresh() = cRefresh()
 proc cocoaSaveState() = cSaveState()
@@ -182,9 +195,12 @@ proc translateNEEvent(ne: NEEvent; e: var input.Event) =
   of neQuit:
     e.kind = QuitEvent
   of neWindowResize:
-    e.kind = WindowResizeEvent
-    e.x = ne.x
-    e.y = ne.y
+    let layout = cocoaGetWindowLayout()
+    e.kind = WindowMetricsEvent
+    e.x = layout.width
+    e.y = layout.height
+    e.scaleX = layout.scaleX
+    e.scaleY = layout.scaleY
   of neWindowClose:
     e.kind = WindowCloseEvent
   of neWindowFocusGained:
@@ -261,7 +277,8 @@ proc cocoaShutdown() = cShutdown()
 
 proc initCocoaDriver*() =
   windowRelays = WindowRelays(
-    createWindow: cocoaCreateWindow, refresh: cocoaRefresh,
+    createWindow: cocoaCreateWindow, getWindowLayout: cocoaGetWindowLayout,
+    refresh: cocoaRefresh,
     saveState: cocoaSaveState, restoreState: cocoaRestoreState,
     setClipRect: cocoaSetClipRect, setCursor: cocoaSetCursor,
     setWindowTitle: cocoaSetWindowTitle)

--- a/src/uirelays/drivers/gtk4_driver.nim
+++ b/src/uirelays/drivers/gtk4_driver.nim
@@ -111,6 +111,7 @@ proc gtk_widget_grab_focus(w: pointer) {.importc, nodecl, cdecl.}
 proc gtk_widget_set_cursor(w, cursor: pointer) {.importc, nodecl, cdecl.}
 proc gtk_widget_get_width(w: pointer): gint {.importc, nodecl, cdecl.}
 proc gtk_widget_get_height(w: pointer): gint {.importc, nodecl, cdecl.}
+proc gtk_widget_get_scale_factor(w: pointer): gint {.importc, nodecl, cdecl.}
 proc gtk_widget_set_focusable(w: pointer; focusable: gboolean) {.importc, nodecl, cdecl.}
 proc gtk_widget_set_hexpand(w: pointer; expand: gboolean) {.importc, nodecl, cdecl.}
 proc gtk_widget_set_vexpand(w: pointer; expand: gboolean) {.importc, nodecl, cdecl.}
@@ -230,6 +231,8 @@ var
   backingSurf: pointer
   backingCr: pointer
   backingW, backingH: int
+  backingPixW, backingPixH: int
+  backingScale: int = 1
   imContext: pointer
   eventQueue: seq[Event]
   modState: set[Modifier]
@@ -309,10 +312,21 @@ proc enqueueTextFromUtf8(s: string) =
       ev.text[i] = '\0'
     pushEvent ev
 
+proc currentScaleFactor(): int {.inline.} =
+  if drawingArea != nil:
+    max(1, gtk_widget_get_scale_factor(drawingArea).int)
+  else:
+    1
+
+proc currentWindowMetricsEvent(width, height: int): Event {.inline.} =
+  let scale = currentScaleFactor().float32
+  Event(kind: WindowMetricsEvent, x: width, y: height, scaleX: scale, scaleY: scale)
+
 proc recreateBacking(w, h: int) =
   ## GTK can emit resize with a transient 0 width or height; do not destroy a good buffer then bail.
   if w <= 0 or h <= 0:
     return
+  let scale = currentScaleFactor()
   if backingCr != nil:
     cairo_destroy(backingCr)
     backingCr = nil
@@ -321,14 +335,32 @@ proc recreateBacking(w, h: int) =
     backingSurf = nil
   backingW = w
   backingH = h
-  backingSurf = cairo_image_surface_create(gint(CAIRO_FORMAT_ARGB32), gint(w), gint(h))
+  backingScale = scale
+  backingPixW = w * scale
+  backingPixH = h * scale
+  backingSurf = cairo_image_surface_create(
+    gint(CAIRO_FORMAT_ARGB32), gint(backingPixW), gint(backingPixH))
   backingCr = cairo_create(backingSurf)
+  cairo_scale(backingCr, gdouble(scale), gdouble(scale))
   cairo_set_source_rgba(backingCr, 1, 1, 1, 1)
   cairo_rectangle(backingCr, 0, 0, gdouble(w), gdouble(h))
   cairo_fill(backingCr)
   cairo_surface_flush(backingSurf)
 
+proc syncBackingScale() =
+  if drawingArea == nil:
+    return
+  let scale = currentScaleFactor()
+  if scale == backingScale:
+    return
+  let width = max(1, gtk_widget_get_width(drawingArea).int)
+  let height = max(1, gtk_widget_get_height(drawingArea).int)
+  if width > 0 and height > 0:
+    recreateBacking(width, height)
+    pushEvent(currentWindowMetricsEvent(width, height))
+
 proc ensureBackingCr() =
+  syncBackingScale()
   if backingCr == nil and win != nil and drawingArea != nil:
     let w = gtk_widget_get_width(drawingArea).int
     let h = gtk_widget_get_height(drawingArea).int
@@ -343,7 +375,7 @@ proc onCloseRequest(self: pointer; data: pointer): gboolean {.cdecl.} =
 
 proc onResize(area: pointer; width, height: gint; data: pointer) {.cdecl.} =
   recreateBacking(width.int, height.int)
-  pushEvent(Event(kind: WindowResizeEvent, x: width.int, y: height.int))
+  pushEvent(currentWindowMetricsEvent(width.int, height.int))
 
 proc onDraw(area: ptr GtkDrawingArea; cr: ptr cairo_t; width, height: gint;
     data: pointer) {.cdecl.} =
@@ -358,9 +390,9 @@ proc onDraw(area: ptr GtkDrawingArea; cr: ptr cairo_t; width, height: gint;
   cairo_surface_flush(backingSurf)
   let crp = cast[pointer](cr)
   cairo_save(crp)
-  if backingW != w or backingH != h:
-    cairo_scale(crp, gdouble(w) / gdouble(max(1, backingW)),
-      gdouble(h) / gdouble(max(1, backingH)))
+  if backingPixW != w or backingPixH != h:
+    cairo_scale(crp, gdouble(w) / gdouble(max(1, backingPixW)),
+      gdouble(h) / gdouble(max(1, backingPixH)))
   cairo_set_source_surface(crp, backingSurf, 0, 0)
   cairo_paint(crp)
   cairo_restore(crp)
@@ -512,12 +544,19 @@ proc gtkCreateWindow(layout: var ScreenLayout) =
     inc guard
   layout.width = max(1, gtk_drawing_area_get_content_width(da).int)
   layout.height = max(1, gtk_drawing_area_get_content_height(da).int)
-  layout.scaleX = 1
-  layout.scaleY = 1
+  let scale = if drawingArea != nil: max(1, gtk_widget_get_scale_factor(drawingArea).int) else: 1
+  layout.scaleX = scale.float32
+  layout.scaleY = scale.float32
   recreateBacking(layout.width, layout.height)
   gtk_widget_set_focusable(drawingArea, G_TRUE)
   gtk_widget_grab_focus(drawingArea)
   gtk_im_context_focus_in(imContext)
+
+proc gtkGetWindowLayout(): ScreenLayout =
+  let width = if drawingArea != nil: max(1, gtk_widget_get_width(drawingArea).int) else: 0
+  let height = if drawingArea != nil: max(1, gtk_widget_get_height(drawingArea).int) else: 0
+  let scale = if drawingArea != nil: max(1, gtk_widget_get_scale_factor(drawingArea).int) else: 1
+  ScreenLayout(width: width, height: height, scaleX: scale.float32, scaleY: scale.float32)
 
 proc gtkRefresh() =
   if backingSurf != nil:
@@ -748,7 +787,8 @@ proc gtkQuitRequest() =
 
 proc initGtk4Driver*() =
   windowRelays = WindowRelays(
-    createWindow: gtkCreateWindow, refresh: gtkRefresh,
+    createWindow: gtkCreateWindow, getWindowLayout: gtkGetWindowLayout,
+    refresh: gtkRefresh,
     saveState: gtkSaveState, restoreState: gtkRestoreState,
     setClipRect: gtkSetClipRect, setCursor: gtkSetCursor,
     setWindowTitle: gtkSetWindowTitle)

--- a/src/uirelays/drivers/sdl2_driver.nim
+++ b/src/uirelays/drivers/sdl2_driver.nim
@@ -21,7 +21,7 @@ proc toSdlColor(c: screen.Color): sdl2.Color =
   result.a = c.a
 
 proc toSdlRect(r: coords.Rect): sdl2.Rect {.inline.} =
-  (r.x, r.y, r.w, r.h)
+  (r.x.cint, r.y.cint, r.w.cint, r.h.cint)
 
 proc getFontPtr(f: Font): FontPtr {.inline.} =
   let idx = f.int - 1
@@ -33,6 +33,7 @@ proc getFontPtr(f: Font): FontPtr {.inline.} =
 var
   window: WindowPtr
   renderer: RendererPtr
+  currentLayout = ScreenLayout(scaleX: 1.0'f32, scaleY: 1.0'f32)
 
 # --- Screen hook implementations ---
 
@@ -50,9 +51,18 @@ proc sdlCreateWindow(layout: var ScreenLayout) =
   window.getSize(w, h)
   layout.width = w
   layout.height = h
-  layout.scaleX = 1
-  layout.scaleY = 1
+  layout.scaleX = 1.0'f32
+  layout.scaleY = 1.0'f32
+  currentLayout = layout
   sdl2.startTextInput()
+
+proc sdlGetWindowLayout(): ScreenLayout =
+  if window != nil:
+    var w, h: cint
+    window.getSize(w, h)
+    currentLayout.width = w
+    currentLayout.height = h
+  currentLayout
 
 proc sdlRefresh() =
   renderer.present()
@@ -83,25 +93,25 @@ proc sdlCloseFont(f: Font) =
     close(fonts[idx].sdlFont)
     fonts[idx].sdlFont = nil
 
-proc sdlMeasureText(f: Font; text: cstring): TextExtent =
+proc sdlMeasureText(f: Font; text: string): TextExtent =
   let fp = getFontPtr(f)
-  if fp != nil and text[0] != '\0':
+  if fp != nil and text.len > 0:
     var w, h: cint
-    discard sizeUtf8(fp, text, addr w, addr h)
+    discard sizeUtf8(fp, cstring(text), addr w, addr h)
     result = TextExtent(w: w, h: h)
 
-proc sdlDrawTextShaded(f: Font; x, y: cint; text: cstring;
+proc sdlDrawTextShaded(f: Font; x, y: int; text: string;
                        fg, bg: screen.Color): TextExtent =
   let fp = getFontPtr(f)
-  if fp == nil or text[0] == '\0': return
-  let surf = renderUtf8Shaded(fp, text, toSdlColor(fg), toSdlColor(bg))
+  if fp == nil or text.len == 0: return
+  let surf = renderUtf8Shaded(fp, cstring(text), toSdlColor(fg), toSdlColor(bg))
   if surf == nil: return
   let tex = renderer.createTextureFromSurface(surf)
   if tex == nil:
     freeSurface(surf)
     return
   var src: sdl2.Rect = (0.cint, 0.cint, surf.w, surf.h)
-  var dst: sdl2.Rect = (x, y, surf.w, surf.h)
+  var dst: sdl2.Rect = (x.cint, y.cint, surf.w, surf.h)
   renderer.copy(tex, addr src, addr dst)
   result = TextExtent(w: surf.w, h: surf.h)
   freeSurface(surf)
@@ -117,13 +127,13 @@ proc sdlFillRect(r: coords.Rect; color: screen.Color) =
   var sdlRect = toSdlRect(r)
   discard renderer.fillRect(sdlRect)
 
-proc sdlDrawLine(x1, y1, x2, y2: cint; color: screen.Color) =
+proc sdlDrawLine(x1, y1, x2, y2: int; color: screen.Color) =
   renderer.setDrawColor(color.r, color.g, color.b, color.a)
-  renderer.drawLine(x1, y1, x2, y2)
+  renderer.drawLine(x1.cint, y1.cint, x2.cint, y2.cint)
 
-proc sdlDrawPoint(x, y: cint; color: screen.Color) =
+proc sdlDrawPoint(x, y: int; color: screen.Color) =
   renderer.setDrawColor(color.r, color.g, color.b, color.a)
-  renderer.drawPoint(x, y)
+  renderer.drawPoint(x.cint, y.cint)
 
 proc sdlSetCursor(c: CursorKind) =
   let sdlCursor = case c
@@ -243,9 +253,13 @@ proc sdlPollEvent(e: var input.Event; flags: set[InputFlag]): bool =
     let wev = sdlEvent.window
     case wev.event
     of WindowEvent_Resized, WindowEvent_SizeChanged:
-      e.kind = WindowResizeEvent
+      e.kind = WindowMetricsEvent
       e.x = wev.data1
       e.y = wev.data2
+      e.scaleX = currentLayout.scaleX
+      e.scaleY = currentLayout.scaleY
+      currentLayout.width = wev.data1
+      currentLayout.height = wev.data2
     of WindowEvent_Close:
       e.kind = WindowCloseEvent
     of WindowEvent_FocusGained:
@@ -327,7 +341,8 @@ proc initSdl2Driver*() =
   if ttfInit() != SdlSuccess:
     quit("TTF init failed")
   windowRelays = WindowRelays(
-    createWindow: sdlCreateWindow, refresh: sdlRefresh,
+    createWindow: sdlCreateWindow, getWindowLayout: sdlGetWindowLayout,
+    refresh: sdlRefresh,
     saveState: sdlSaveState, restoreState: sdlRestoreState,
     setClipRect: sdlSetClipRect, setCursor: sdlSetCursor,
     setWindowTitle: sdlSetWindowTitle)

--- a/src/uirelays/drivers/sdl3_driver.nim
+++ b/src/uirelays/drivers/sdl3_driver.nim
@@ -2,13 +2,15 @@
 
 import sdl3
 import sdl3_ttf
-import std/[hashes, os, tables]
+import std/[hashes, math, os, tables]
 import ../coords, ../input, ../screen
 
 # --- Font handle management ---
 
 type
   FontSlot = object
+    path: string
+    logicalSize: int
     ttfFont: sdl3_ttf.Font
     metrics: FontMetrics
 
@@ -27,12 +29,13 @@ type
 
   TextCacheEntry = object
     texture: sdl3.Texture
+    texW, texH: int
     extent: TextExtent
     lastUsed: int
 
   ClipState = object
     enabled: bool
-    rect: sdl3.Rect
+    rect: coords.Rect
 
 var fonts: seq[FontSlot]
 
@@ -83,6 +86,9 @@ var
   drawColor: screen.Color
   clipStack: seq[ClipState]
   currentClip: ClipState
+  pixelScaleX: float32 = 1.0'f32
+  pixelScaleY: float32 = 1.0'f32
+  currentLayout = ScreenLayout(scaleX: 1.0'f32, scaleY: 1.0'f32)
 
 proc clearMeasureCache() =
   measureCache.clear()
@@ -117,6 +123,37 @@ proc closeAllFonts() =
       slot.ttfFont = nil
   fonts.setLen(0)
 
+proc fontScale(): float32 {.inline.} =
+  max(pixelScaleX, pixelScaleY)
+
+proc logicalToPixel(value: int; scale: float32): float32 {.inline.} =
+  value.float32 * scale
+
+proc logicalToPixelRect(r: coords.Rect): FRect {.inline.} =
+  FRect(
+    x: logicalToPixel(r.x, pixelScaleX),
+    y: logicalToPixel(r.y, pixelScaleY),
+    w: logicalToPixel(r.w, pixelScaleX),
+    h: logicalToPixel(r.h, pixelScaleY))
+
+proc logicalToPixelClipRect(r: coords.Rect): sdl3.Rect {.inline.} =
+  sdl3.Rect(
+    x: floor(logicalToPixel(r.x, pixelScaleX).float64).cint,
+    y: floor(logicalToPixel(r.y, pixelScaleY).float64).cint,
+    w: ceil(logicalToPixel(r.w, pixelScaleX).float64).cint,
+    h: ceil(logicalToPixel(r.h, pixelScaleY).float64).cint)
+
+proc pixelExtentToLogical(value: int; scale: float32): int {.inline.} =
+  if value <= 0:
+    0
+  elif scale <= 0:
+    value
+  else:
+    max(1, ceil(value.float64 / scale.float64).int)
+
+proc scaledFontSize(size: int): float32 {.inline.} =
+  max(1.0, size.float64 * fontScale().float64).float32
+
 proc resetSdlState() =
   clearImageCache()
   clearTextCache()
@@ -126,6 +163,9 @@ proc resetSdlState() =
   clipStack.setLen(0)
   currentClip = ClipState()
   drawColorValid = false
+  pixelScaleX = 1.0'f32
+  pixelScaleY = 1.0'f32
+  currentLayout = ScreenLayout(scaleX: 1.0'f32, scaleY: 1.0'f32)
   if ren != nil:
     destroyRenderer(ren)
     ren = nil
@@ -144,9 +184,87 @@ proc applyClipState() =
   if ren == nil:
     return
   if currentClip.enabled:
-    discard setRenderClipRect(ren, addr currentClip.rect)
+    var rect = logicalToPixelClipRect(currentClip.rect)
+    discard setRenderClipRect(ren, addr rect)
   else:
     discard setRenderClipRect(ren, cast[ptr sdl3.Rect](nil))
+
+proc refreshFontMetrics(slot: var FontSlot) =
+  if slot.ttfFont == nil:
+    slot.metrics = FontMetrics()
+    return
+  let scale = fontScale()
+  slot.metrics = FontMetrics(
+    ascent: pixelExtentToLogical(sdl3_ttf.getFontAscent(slot.ttfFont), scale),
+    descent: pixelExtentToLogical(sdl3_ttf.getFontDescent(slot.ttfFont), scale),
+    lineHeight: pixelExtentToLogical(sdl3_ttf.getFontLineSkip(slot.ttfFont), scale))
+
+proc reopenFontSlot(slot: var FontSlot) =
+  if slot.ttfFont != nil:
+    sdl3_ttf.closeFont(slot.ttfFont)
+    slot.ttfFont = nil
+  if slot.path.len == 0:
+    slot.metrics = FontMetrics()
+    return
+  slot.ttfFont = sdl3_ttf.openFont(cstring(slot.path), scaledFontSize(slot.logicalSize))
+  if slot.ttfFont == nil:
+    slot.metrics = FontMetrics()
+    return
+  sdl3_ttf.setFontHinting(slot.ttfFont, sdl3_ttf.hintingLightSubpixel)
+  refreshFontMetrics(slot)
+
+proc refreshFontsForScaleChange() =
+  clearMeasureCache()
+  clearTextCache()
+  for slot in fonts.mitems:
+    if slot.path.len > 0:
+      reopenFontSlot(slot)
+
+proc syncWindowLayout(layout: var ScreenLayout) =
+  if win == nil:
+    return
+  var logicalW: cint = 0
+  var logicalH: cint = 0
+  var pixelW: cint = 0
+  var pixelH: cint = 0
+  discard getWindowSize(win, logicalW, logicalH)
+  discard getWindowSizeInPixels(win, pixelW, pixelH)
+  layout.width = logicalW
+  layout.height = logicalH
+
+  let prevScaleX = pixelScaleX
+  let prevScaleY = pixelScaleY
+  let fallbackScale = max(1.0'f32, getWindowDisplayScale(win))
+  let scaleX =
+    if logicalW > 0 and pixelW > 0: pixelW.float32 / logicalW.float32
+    else: fallbackScale
+  let scaleY =
+    if logicalH > 0 and pixelH > 0: pixelH.float32 / logicalH.float32
+    else: fallbackScale
+  pixelScaleX = max(1.0'f32, scaleX)
+  pixelScaleY = max(1.0'f32, scaleY)
+  layout.scaleX = pixelScaleX
+  layout.scaleY = pixelScaleY
+  currentLayout = layout
+
+  if abs(pixelScaleX - prevScaleX) > 0.001'f32 or
+     abs(pixelScaleY - prevScaleY) > 0.001'f32:
+    refreshFontsForScaleChange()
+    if currentClip.enabled:
+      applyClipState()
+
+proc sdlGetWindowLayout(): ScreenLayout =
+  if win != nil:
+    syncWindowLayout(currentLayout)
+  currentLayout
+
+proc syncWindowEvent(e: var input.Event) =
+  syncWindowLayout(currentLayout)
+  e.kind = WindowMetricsEvent
+  e.x = currentLayout.width
+  e.y = currentLayout.height
+  e.scaleX = currentLayout.scaleX
+  e.scaleY = currentLayout.scaleY
 
 proc nextTextCacheGeneration(): int =
   inc textCacheGeneration
@@ -204,17 +322,13 @@ proc resolveFontPath(path: string): string =
 proc sdlCreateWindow(layout: var ScreenLayout) =
   if ren != nil or win != nil:
     resetSdlState()
-  let winFlags = if layout.fullScreen: WINDOW_FULLSCREEN
-                 else: WINDOW_RESIZABLE
+  let winFlags =
+    if layout.fullScreen: WINDOW_FULLSCREEN or WINDOW_HIGH_PIXEL_DENSITY
+    else: WINDOW_RESIZABLE or WINDOW_HIGH_PIXEL_DENSITY
   discard createWindowAndRenderer(cstring"NimEdit",
     layout.width.cint, layout.height.cint, winFlags, win, ren)
   discard startTextInput(win)
-  var w, h: cint
-  discard getWindowSize(win, w, h)
-  layout.width = w
-  layout.height = h
-  layout.scaleX = 1
-  layout.scaleY = 1
+  syncWindowLayout(layout)
   currentClip = ClipState()
   applyClipState()
 
@@ -234,7 +348,7 @@ proc sdlRestoreState() =
 proc sdlSetClipRect(r: coords.Rect) =
   currentClip = ClipState(
     enabled: true,
-    rect: sdl3.Rect(x: r.x.cint, y: r.y.cint, w: r.w.cint, h: r.h.cint))
+    rect: r)
   applyClipState()
 
 proc sdlOpenFont(path: string; size: int;
@@ -242,13 +356,18 @@ proc sdlOpenFont(path: string; size: int;
   let resolvedPath = resolveFontPath(path)
   if resolvedPath.len == 0:
     return screen.Font(0)
-  let f = sdl3_ttf.openFont(cstring(resolvedPath), size.cfloat)
+  let f = sdl3_ttf.openFont(cstring(resolvedPath), scaledFontSize(size))
   if f == nil: return screen.Font(0)
   sdl3_ttf.setFontHinting(f, sdl3_ttf.hintingLightSubpixel)
-  metrics.ascent = sdl3_ttf.getFontAscent(f)
-  metrics.descent = sdl3_ttf.getFontDescent(f)
-  metrics.lineHeight = sdl3_ttf.getFontLineSkip(f)
-  fonts.add FontSlot(ttfFont: f, metrics: metrics)
+  let scale = fontScale()
+  metrics.ascent = pixelExtentToLogical(sdl3_ttf.getFontAscent(f), scale)
+  metrics.descent = pixelExtentToLogical(sdl3_ttf.getFontDescent(f), scale)
+  metrics.lineHeight = pixelExtentToLogical(sdl3_ttf.getFontLineSkip(f), scale)
+  fonts.add FontSlot(
+    path: resolvedPath,
+    logicalSize: size,
+    ttfFont: f,
+    metrics: metrics)
   clearMeasureCache()
   clearTextCache()
   result = screen.Font(fonts.len)
@@ -258,6 +377,9 @@ proc sdlCloseFont(f: screen.Font) =
   if idx >= 0 and idx < fonts.len and fonts[idx].ttfFont != nil:
     sdl3_ttf.closeFont(fonts[idx].ttfFont)
     fonts[idx].ttfFont = nil
+    fonts[idx].path.setLen(0)
+    fonts[idx].logicalSize = 0
+    fonts[idx].metrics = FontMetrics()
     clearMeasureCache()
     clearTextCache()
 
@@ -270,7 +392,10 @@ proc getCachedExtent(f: screen.Font; text: string): TextExtent =
     return measureCache[key]
   var w, h: cint
   discard sdl3_ttf.getStringSize(fp, cstring(text), 0, w, h)
-  result = TextExtent(w: w, h: h)
+  let scale = fontScale()
+  result = TextExtent(
+    w: pixelExtentToLogical(w, scale),
+    h: pixelExtentToLogical(h, scale))
   measureCache[key] = result
 
 proc sdlMeasureText(f: screen.Font; text: string): TextExtent =
@@ -295,6 +420,8 @@ proc getCachedTextEntry(f: screen.Font; text: string;
   discard setTextureBlendMode(tex, BLENDMODE_BLEND)
   let entry = TextCacheEntry(
     texture: tex,
+    texW: surf.w.int,
+    texH: surf.h.int,
     extent: getCachedExtent(f, text),
     lastUsed: nextTextCacheGeneration())
   destroySurface(surf)
@@ -308,13 +435,19 @@ proc sdlDrawText(f: screen.Font; x, y: int; text: string;
   if entry.texture == nil:
     return
   if bg.a != 0 and entry.extent.w > 0 and entry.extent.h > 0:
-    var bgRect = FRect(x: x.cfloat, y: y.cfloat,
-                       w: entry.extent.w.cfloat, h: entry.extent.h.cfloat)
+    var bgRect = FRect(
+      x: logicalToPixel(x, pixelScaleX),
+      y: logicalToPixel(y, pixelScaleY),
+      w: entry.texW.float32,
+      h: entry.texH.float32)
     ensureDrawColor(bg)
     discard renderFillRect(ren, addr bgRect)
-  var src = FRect(x: 0, y: 0, w: entry.extent.w.cfloat, h: entry.extent.h.cfloat)
-  var dst = FRect(x: x.cfloat, y: y.cfloat,
-                  w: entry.extent.w.cfloat, h: entry.extent.h.cfloat)
+  var src = FRect(x: 0, y: 0, w: entry.texW.float32, h: entry.texH.float32)
+  var dst = FRect(
+    x: logicalToPixel(x, pixelScaleX),
+    y: logicalToPixel(y, pixelScaleY),
+    w: entry.texW.float32,
+    h: entry.texH.float32)
   discard renderTexture(ren, entry.texture, addr src, addr dst)
   result = entry.extent
 
@@ -325,17 +458,21 @@ proc sdlGetFontMetrics(f: screen.Font): FontMetrics =
 
 proc sdlFillRect(r: coords.Rect; color: screen.Color) =
   ensureDrawColor(color)
-  var fr = FRect(x: r.x.cfloat, y: r.y.cfloat,
-                 w: r.w.cfloat, h: r.h.cfloat)
+  var fr = logicalToPixelRect(r)
   discard renderFillRect(ren, addr fr)
 
 proc sdlDrawLine(x1, y1, x2, y2: int; color: screen.Color) =
   ensureDrawColor(color)
-  discard renderLine(ren, x1.cfloat, y1.cfloat, x2.cfloat, y2.cfloat)
+  discard renderLine(
+    ren,
+    logicalToPixel(x1, pixelScaleX),
+    logicalToPixel(y1, pixelScaleY),
+    logicalToPixel(x2, pixelScaleX),
+    logicalToPixel(y2, pixelScaleY))
 
 proc sdlDrawPoint(x, y: int; color: screen.Color) =
   ensureDrawColor(color)
-  discard renderPoint(ren, x.cfloat, y.cfloat)
+  discard renderPoint(ren, logicalToPixel(x, pixelScaleX), logicalToPixel(y, pixelScaleY))
 
 proc getImageSlot(img: screen.Image): ptr ImageSlot {.inline.} =
   let idx = img.int - 1
@@ -377,9 +514,7 @@ proc sdlDrawImage(img: screen.Image; src, dst: coords.Rect) =
   var srcRect = FRect(
     x: src.x.cfloat, y: src.y.cfloat,
     w: src.w.cfloat, h: src.h.cfloat)
-  var dstRect = FRect(
-    x: dst.x.cfloat, y: dst.y.cfloat,
-    w: dst.w.cfloat, h: dst.h.cfloat)
+  var dstRect = logicalToPixelRect(dst)
   discard renderTexture(ren, slot[].texture, addr srcRect, addr dstRect)
 
 proc sdlSetCursor(c: CursorKind) =
@@ -511,10 +646,10 @@ proc translateEvent(sdlEvent: sdl3.Event; e: var input.Event) =
   let evType = uint32(sdlEvent.common.`type`)
   if evType == uint32(EVENT_QUIT):
     e.kind = QuitEvent
-  elif evType == uint32(EVENT_WINDOW_RESIZED):
-    e.kind = WindowResizeEvent
-    e.x = sdlEvent.window.data1
-    e.y = sdlEvent.window.data2
+  elif evType == uint32(EVENT_WINDOW_RESIZED) or
+       evType == uint32(EVENT_WINDOW_PIXEL_SIZE_CHANGED) or
+       evType == uint32(EVENT_WINDOW_DISPLAY_SCALE_CHANGED):
+    syncWindowEvent(e)
   elif evType == uint32(EVENT_WINDOW_CLOSE_REQUESTED):
     e.kind = WindowCloseEvent
   elif evType == uint32(EVENT_WINDOW_FOCUS_GAINED):
@@ -602,7 +737,8 @@ proc initSdl3Driver*() =
   if not sdl3_ttf.init():
     quit("TTF3 init failed")
   windowRelays = WindowRelays(
-    createWindow: sdlCreateWindow, refresh: sdlRefresh,
+    createWindow: sdlCreateWindow, getWindowLayout: sdlGetWindowLayout,
+    refresh: sdlRefresh,
     saveState: sdlSaveState, restoreState: sdlRestoreState,
     setClipRect: sdlSetClipRect, setCursor: sdlSetCursor,
     setWindowTitle: sdlSetWindowTitle)

--- a/src/uirelays/drivers/winapi_driver.nim
+++ b/src/uirelays/drivers/winapi_driver.nim
@@ -460,9 +460,11 @@ proc wndProc(hwnd: HWND; msg: UINT; wp: WPARAM; lp: LPARAM): LRESULT {.stdcall.}
       gWidth = newW
       gHeight = newH
       recreateBackBuffer()
-      var e = input.Event(kind: WindowResizeEvent)
+      var e = input.Event(kind: WindowMetricsEvent)
       e.x = gWidth
       e.y = gHeight
+      e.scaleX = 1.0'f32
+      e.scaleY = 1.0'f32
       pushEvent(e)
     return 0
 
@@ -609,10 +611,17 @@ proc winCreateWindow(layout: var ScreenLayout) =
   gHeight = rc.bottom - rc.top
   layout.width = gWidth
   layout.height = gHeight
-  layout.scaleX = 1
-  layout.scaleY = 1
+  layout.scaleX = 1.0'f32
+  layout.scaleY = 1.0'f32
 
   recreateBackBuffer()
+
+proc winGetWindowLayout(): ScreenLayout =
+  ScreenLayout(
+    width: gWidth.int,
+    height: gHeight.int,
+    scaleX: 1.0'f32,
+    scaleY: 1.0'f32)
 
 proc winRefresh() =
   discard InvalidateRect(gHwnd, nil, 0)
@@ -907,7 +916,8 @@ proc setDpiAware() =
 proc initWinapiDriver*() =
   setDpiAware()
   windowRelays = WindowRelays(
-    createWindow: winCreateWindow, refresh: winRefresh,
+    createWindow: winCreateWindow, getWindowLayout: winGetWindowLayout,
+    refresh: winRefresh,
     saveState: winSaveState, restoreState: winRestoreState,
     setClipRect: winSetClipRect, setCursor: winSetCursor,
     setWindowTitle: winSetWindowTitle)

--- a/src/uirelays/drivers/x11_driver.nim
+++ b/src/uirelays/drivers/x11_driver.nim
@@ -576,9 +576,11 @@ proc processXEvent(xev: XEvent) =
       gWidth = newW
       gHeight = newH
       recreateBackBuffer()
-      var e = input.Event(kind: WindowResizeEvent)
+      var e = input.Event(kind: WindowMetricsEvent)
       e.x = gWidth
       e.y = gHeight
+      e.scaleX = 1.0'f32
+      e.scaleY = 1.0'f32
       pushEvent(e)
 
   of ClientMessage:
@@ -713,8 +715,8 @@ proc x11CreateWindow(layout: var ScreenLayout) =
   gHeight = layout.height.cint
   recreateBackBuffer()
 
-  layout.scaleX = 1
-  layout.scaleY = 1
+  layout.scaleX = 1.0'f32
+  layout.scaleY = 1.0'f32
 
 proc x11Refresh() =
   if gBackPixmap != None:
@@ -734,6 +736,13 @@ proc x11SetClipRect(r: coords.Rect) =
     width: r.w.cushort, height: r.h.cushort)
   discard XSetClipRectangles(gDisplay, gGC, 0, 0, addr xr, 1, 0)
   discard XftDrawSetClipRectangles(gXftDraw, 0, 0, addr xr, 1)
+
+proc x11GetWindowLayout(): ScreenLayout =
+  ScreenLayout(
+    width: gWidth.int,
+    height: gHeight.int,
+    scaleX: 1.0'f32,
+    scaleY: 1.0'f32)
 
 proc x11OpenFont(path: string; size: int;
                  metrics: var FontMetrics): screen.Font =
@@ -954,7 +963,8 @@ proc x11QuitRequest() =
 
 proc initX11Driver*() =
   windowRelays = WindowRelays(
-    createWindow: x11CreateWindow, refresh: x11Refresh,
+    createWindow: x11CreateWindow, getWindowLayout: x11GetWindowLayout,
+    refresh: x11Refresh,
     saveState: x11SaveState, restoreState: x11RestoreState,
     setClipRect: x11SetClipRect, setCursor: x11SetCursor,
     setWindowTitle: x11SetWindowTitle)

--- a/src/uirelays/input.nim
+++ b/src/uirelays/input.nim
@@ -20,7 +20,7 @@ type
     NoEvent,
     KeyDownEvent, KeyUpEvent, TextInputEvent,
     MouseDownEvent, MouseUpEvent, MouseMoveEvent, MouseWheelEvent,
-    WindowResizeEvent, WindowCloseEvent,
+    WindowResizeEvent, WindowMetricsEvent, WindowCloseEvent,
     WindowFocusGainedEvent, WindowFocusLostEvent,
     QuitEvent
 
@@ -39,6 +39,7 @@ type
     mods*: set[Modifier]
     text*: array[4, char]  ## TextInputEvent: one UTF-8 codepoint, no alloc
     x*, y*: int            ## mouse position, scroll delta, or new window size
+    scaleX*, scaleY*: float32 ## WindowMetricsEvent: current logical-to-device scale
     button*: MouseButton   ## MouseDownEvent/MouseUpEvent: which button
     clicks*: int           ## number of consecutive clicks (double-click = 2)
 

--- a/src/uirelays/screen.nim
+++ b/src/uirelays/screen.nim
@@ -19,7 +19,7 @@ type
   ScreenLayout* = object
     width*, height*: int
     pitch*: int
-    scaleX*, scaleY*: int
+    scaleX*, scaleY*: float32
     fullScreen*: bool
 
   CursorKind* = enum
@@ -28,6 +28,7 @@ type
 
   WindowRelays* = object
     createWindow*: proc (layout: var ScreenLayout) {.nimcall.}
+    getWindowLayout*: proc (): ScreenLayout {.nimcall.}
     refresh*: proc () {.nimcall.}
     saveState*: proc () {.nimcall.}
     restoreState*: proc () {.nimcall.}
@@ -57,6 +58,7 @@ proc `==`*(a, b: Image): bool {.borrow.}
 
 var windowRelays* = WindowRelays(
   createWindow: proc (layout: var ScreenLayout) = discard,
+  getWindowLayout: proc (): ScreenLayout = ScreenLayout(scaleX: 1.0'f32, scaleY: 1.0'f32),
   refresh: proc () = discard,
   saveState: proc () = discard,
   restoreState: proc () = discard,
@@ -82,9 +84,15 @@ var drawRelays* = DrawRelays(
 
 # Convenience wrappers
 proc createWindow*(requestedW, requestedH: int; fullScreen = false): ScreenLayout =
-  result = ScreenLayout(width: requestedW, height: requestedH, fullScreen: fullScreen)
+  result = ScreenLayout(
+    width: requestedW,
+    height: requestedH,
+    scaleX: 1.0'f32,
+    scaleY: 1.0'f32,
+    fullScreen: fullScreen)
   windowRelays.createWindow(result)
 
+proc getWindowLayout*(): ScreenLayout = windowRelays.getWindowLayout()
 proc refresh*() = windowRelays.refresh()
 proc saveState*() = windowRelays.saveState()
 proc restoreState*() = windowRelays.restoreState()


### PR DESCRIPTION
  This updates the windowing API to expose HiDPI metrics explicitly while keeping the existing logical-coordinate rendering model.

  Main changes:

  - change ScreenLayout.scaleX/scaleY from int to float32
  - add getWindowLayout() so callers can query current logical size and scale
  - add WindowMetricsEvent carrying logical width/height plus scaleX/scaleY
  - update SDL3 to handle HiDPI internally by rendering in device pixels while keeping logical coordinates above the driver boundary
  - update GTK4 to use a HiDPI backing surface while preserving existing logical text/layout behavior
  - wire getWindowLayout() through Cocoa, GTK4, SDL2, X11, and WinAPI
  - update examples and driver docs to use the new event model

  ## Design

  The intent is to keep scaling driver-owned rather than pushing pixel/logical conversions into the upper layer.

  That means:

  - app code continues to work in logical coordinates
  - drivers decide how to map logical units to device pixels
  - apps can now react explicitly to runtime window metric changes, including monitor scale changes

  ## Verification

  Built successfully with:

  - nim c -d:gtk4 examples/todo.nim
  - nim c -d:gtk4 examples/hello.nim
  - nim c -d:sdl3 examples/hello.nim
  - nim c examples/hello.nim

  ## Notes

  WindowResizeEvent is still accepted in the examples for compatibility, but WindowMetricsEvent is now the preferred event for window size/scale updates.
