### PR TITLE
feat(cocoa): add image loading and drawing support

### DIFF
--- a/src/uirelays/drivers/cocoa_backend.m
+++ b/src/uirelays/drivers/cocoa_backend.m
@@ -444,6 +444,63 @@ void cocoa_drawText(int fontHandle, int x, int y, const char *text,
   CFRelease(str);
 }
 
+/* ---- Image management ------------------------------------------------- */
+
+#define MAX_IMAGES 128
+
+static CGImageRef imageSlots[MAX_IMAGES];
+static int imageCount = 0;
+
+int cocoa_loadImage(const char *path) {
+  if (!path || path[0] == '\0') return 0;
+  if (imageCount >= MAX_IMAGES) return 0;
+
+  CFStringRef cfPath = CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8);
+  if (!cfPath) return 0;
+  CFURLRef url = CFURLCreateWithFileSystemPath(NULL, cfPath, kCFURLPOSIXPathStyle, false);
+  CFRelease(cfPath);
+  if (!url) return 0;
+
+  CGImageSourceRef source = CGImageSourceCreateWithURL(url, NULL);
+  CFRelease(url);
+  if (!source) return 0;
+
+  CGImageRef cgImage = CGImageSourceCreateImageAtIndex(source, 0, NULL);
+  CFRelease(source);
+  if (!cgImage) return 0;
+
+  int idx = imageCount++;
+  imageSlots[idx] = cgImage;
+  return idx + 1; /* 1-based handle */
+}
+
+void cocoa_drawImage(int handle, int srcX, int srcY, int srcW, int srcH,
+                     int dstX, int dstY, int dstW, int dstH) {
+  int idx = handle - 1;
+  if (idx < 0 || idx >= imageCount || !imageSlots[idx] || !backingCtx) return;
+
+  CGImageRef img = imageSlots[idx];
+  size_t imgW = CGImageGetWidth(img);
+  size_t imgH = CGImageGetHeight(img);
+
+  CGRect srcRect = CGRectMake(srcX, srcY, srcW, srcH);
+  CGRect dstRect = CGRectMake(dstX, dstY, dstW, dstH);
+
+  CGContextSaveGState(backingCtx);
+  /* Clip to destination rect */
+  CGContextClipToRect(backingCtx, dstRect);
+  /* Scale and translate so the source rect maps to the destination rect */
+  CGFloat scaleX = dstW / (CGFloat)srcW;
+  CGFloat scaleY = dstH / (CGFloat)srcH;
+  CGContextTranslateCTM(backingCtx, dstX - srcX * scaleX, dstY - srcY * scaleY);
+  CGContextScaleCTM(backingCtx, scaleX, scaleY);
+  /* Flip Y because CGImage is bottom-up and our view is flipped */
+  CGContextTranslateCTM(backingCtx, 0, imgH);
+  CGContextScaleCTM(backingCtx, 1.0, -1.0);
+  CGContextDrawImage(backingCtx, CGRectMake(0, 0, imgW, imgH), img);
+  CGContextRestoreGState(backingCtx);
+}
+
 void cocoa_setClipRect(int x, int y, int w, int h) {
   if (!backingCtx) return;
   CGContextRestoreGState(backingCtx);

--- a/src/uirelays/drivers/cocoa_driver.nim
+++ b/src/uirelays/drivers/cocoa_driver.nim
@@ -81,6 +81,10 @@ proc cFillRect(x, y, w, h: cint; r, g, b, a: cint) {.importc: "cocoa_fillRect", 
 proc cDrawLine(x1, y1, x2, y2: cint; r, g, b, a: cint) {.importc: "cocoa_drawLine", cdecl.}
 proc cDrawPoint(x, y: cint; r, g, b, a: cint) {.importc: "cocoa_drawPoint", cdecl.}
 
+proc cLoadImage(path: cstring): cint {.importc: "cocoa_loadImage", cdecl.}
+proc cDrawImage(handle, srcX, srcY, srcW, srcH, dstX, dstY, dstW, dstH: cint)
+  {.importc: "cocoa_drawImage", cdecl.}
+
 proc cSetClipRect(x, y, w, h: cint) {.importc: "cocoa_setClipRect", cdecl.}
 proc cSaveState() {.importc: "cocoa_saveState", cdecl.}
 proc cRestoreState() {.importc: "cocoa_restoreState", cdecl.}
@@ -114,6 +118,15 @@ proc cocoaRestoreState() = cRestoreState()
 
 proc cocoaSetClipRect(r: Rect) =
   cSetClipRect(r.x.cint, r.y.cint, r.w.cint, r.h.cint)
+
+proc cocoaLoadImage(path: string): Image =
+  let handle = cLoadImage(path.cstring)
+  result = Image(handle)
+
+proc cocoaDrawImage(img: Image; src, dst: Rect) =
+  cDrawImage(img.int.cint,
+             src.x.cint, src.y.cint, src.w.cint, src.h.cint,
+             dst.x.cint, dst.y.cint, dst.w.cint, dst.h.cint)
 
 proc cocoaOpenFont(path: string; size: int;
                    metrics: var FontMetrics): Font =
@@ -271,7 +284,8 @@ proc initCocoaDriver*() =
     drawText: cocoaDrawText)
   drawRelays = DrawRelays(
     fillRect: cocoaFillRect, drawLine: cocoaDrawLine,
-    drawPoint: cocoaDrawPoint)
+    drawPoint: cocoaDrawPoint,
+    loadImage: cocoaLoadImage, drawImage: cocoaDrawImage)
   inputRelays = InputRelays(
     pollEvent: cocoaPollEvent, waitEvent: cocoaWaitEvent,
     getTicks: cocoaGetTicks, sleep: cocoaDelay,


### PR DESCRIPTION
Add cocoa_loadImage and cocoa_drawImage to the Cocoa backend, along with corresponding Nim procs cocoaLoadImage and cocoaDrawImage. This enables image rendering in the Cocoa driver.