### PR TITLE
HiDPI: the scale survives window creation, and (px N) is logical

### DIFF
--- a/apps/focim.nim
+++ b/apps/focim.nim
@@ -177,6 +177,12 @@ var gUiScale = 100
   ## A global because every `fontForSize` call needs it and none of them cares
   ## about anything else the window knows.
 
+proc scaledPx(value: int): int {.inline.} =
+  ## The same turn from logical to physical that `fontForSize` does for a font
+  ## size, for the handful of pixel sizes this file states itself. The `(px N)`
+  ## sizes in a layout are `resolve`'s business, not this one's.
+  value * gUiScale div 100
+
 proc fontForSize(fonts: var Table[int, Font]; size: int): Font =
   ## `size` and the cache key are logical; only what reaches `openFont` is
   ## physical.
@@ -429,7 +435,9 @@ proc reparseConfig(src: string; width, height, lineHeight: int;
   if parsed.error.len > 0:
     note = "config: " & parsed.error
     return
-  let cells = parsed.layout.resolve(width, height, lineHeight, gap = 2)
+  let cells = parsed.layout.resolve(width, height, lineHeight,
+                                    padding = scaledPx(6), gap = scaledPx(2),
+                                    uiScale = gUiScale)
   for name in RequiredCells:
     if name notin cells:
       note = "config: no '" & name & "' cell"
@@ -934,7 +942,9 @@ proc main =
           (if job.truncated: ", stopped at " & $MaxIndexFiles & " files" else: "")
         job = IndexJob()
 
-    let cells = layout.resolve(width, height, fm.lineHeight, gap = 2)
+    let cells = layout.resolve(width, height, fm.lineHeight,
+                               padding = scaledPx(6), gap = scaledPx(2),
+                               uiScale = gUiScale)
     # A layout may have dropped the cell that had the focus.
     if focus notin cells: focus = "editor"
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -60,7 +60,7 @@ vertically, so its children state heights.
 
 | Size | Meaning |
 |------|---------|
-| `(px 250)` | 250 of whatever unit the driver draws in. |
+| `(px 250)` | 250 *logical* pixels: `resolve`'s `uiScale` turns them into the display's, so the same config gives the same window on a 4K laptop panel as on a 96 dpi monitor. |
 | `(lines 5)` | `5 * lineHeight`, plus `padding` above and below. |
 | `(stretch 2)` | Two shares of what the fixed sizes leave over. |
 

--- a/examples/layout_demo.nim
+++ b/examples/layout_demo.nim
@@ -60,7 +60,11 @@ proc main =
           running = false
       else: discard
 
-    let cells = parsed.resolve(width, height, fm.lineHeight)
+    # `uiScale` is what makes the `(px 30)` and `(px 200)` above hold as many
+    # pixels as they are worth on this display, exactly as `scaled` did for
+    # the font size.
+    let cells = parsed.resolve(width, height, fm.lineHeight,
+                               uiScale = win.uiScale)
 
     # hit test
     let hit = cells.hitTest(mouseX, mouseY)

--- a/src/uirelays/drivers/winapi_driver.nim
+++ b/src/uirelays/drivers/winapi_driver.nim
@@ -626,6 +626,12 @@ proc wndProc(hwnd: HWND; msg: UINT; wp: WPARAM; lp: LPARAM): LRESULT {.stdcall.}
 # ---- Screen hook implementations ----
 
 proc winCreateWindow(layout: var ScreenLayout) =
+  # Seed the scale before there is a window: `CreateWindowExW` and `ShowWindow`
+  # below both send WM_SIZE synchronously, and the event that lands in the
+  # queue carries `gUiScale` with it. Left at the 100 default, that event
+  # reaches the app one frame later and tells it the display is a 96 dpi one,
+  # undoing the real scale this proc goes on to report.
+  gUiScale = currentUiScale()
   gHinstance = GetModuleHandleW(nil)
   let className = newWideCString("NimEditWinAPI")
 
@@ -671,6 +677,12 @@ proc winCreateWindow(layout: var ScreenLayout) =
   layout.scaleY = 1
   gUiScale = currentUiScale()
   layout.uiScale = gUiScale
+  # The seed above is the system DPI, which is not this window's on a desktop
+  # of mixed density -- only now can `GetDpiForWindow` be asked. Anything the
+  # messages during creation already queued gets the same answer this call
+  # hands back, so that no event ever contradicts it.
+  for e in eventQueue.mitems:
+    if e.kind == WindowMetricsEvent: e.uiScale = gUiScale
 
   recreateBackBuffer()
 

--- a/src/uirelays/layout.nim
+++ b/src/uirelays/layout.nim
@@ -24,7 +24,9 @@
 # A box may state its size along the axis its parent divides -- a height inside
 # `rows`, a width inside `cols`:
 #
-#   (px 250)     250 of whatever unit the driver draws in
+#   (px 250)     250 *logical* pixels: `resolve`'s `uiScale` turns them into
+#                the display's, so one layout describes the same window on a
+#                4K laptop panel as on a 96 dpi monitor
 #   (lines 5)    5 * lineHeight, plus the padding above and below
 #   (stretch 2)  two shares of what the fixed sizes leave over
 #
@@ -218,13 +220,13 @@ proc parseLayout*(s: string): Layout =
 # Resolving
 # ---------------------------------------------------------------------------
 
-proc fixedSize(sz: CellSize; lineHeight, padding: int): int =
+proc fixedSize(sz: CellSize; lineHeight, padding, uiScale: int): int =
   case sz.kind
-  of skPixels: result = sz.value
+  of skPixels: result = sz.value * uiScale div 100
   of skLines: result = sz.value * lineHeight + 2 * padding
   of skStretch: result = 0
 
-proc place(n: Node; r: Rect; lineHeight, padding, gap: int;
+proc place(n: Node; r: Rect; lineHeight, padding, gap, uiScale: int;
            res: var Table[string, Rect]) =
   if n.kind == nkCell:
     res[n.name] = r
@@ -245,7 +247,7 @@ proc place(n: Node; r: Rect; lineHeight, padding, gap: int;
       weights += sz.value
       lastStretch = i
     else:
-      sizes[i] = fixedSize(sz, lineHeight, padding)
+      sizes[i] = fixedSize(sz, lineHeight, padding, uiScale)
       fixed += sizes[i]
 
   let remaining = max(0, axis - fixed - gaps)
@@ -265,21 +267,27 @@ proc place(n: Node; r: Rect; lineHeight, padding, gap: int;
   for i in 0 ..< n.children.len:
     let sub = if vertical: Rect(x: r.x, y: pos, w: r.w, h: sizes[i])
               else: Rect(x: pos, y: r.y, w: sizes[i], h: r.h)
-    place(n.children[i], sub, lineHeight, padding, gap, res)
+    place(n.children[i], sub, lineHeight, padding, gap, uiScale, res)
     pos += sizes[i] + gap
 
 proc resolve*(layout: Layout; screenW, screenH: int;
               lineHeight: int = 20; padding: int = 6;
-              gap: int = 0): Table[string, Rect] =
+              gap: int = 0; uiScale: int = 100): Table[string, Rect] =
   ## Resolve the layout into named Rects given the window's dimensions.
   ## `lineHeight` resolves `(lines N)` sizes, `padding` is added above and
   ## below such a text area, and `gap` inserts pixel gaps between adjacent
   ## boxes so that the background can show through as a border.
+  ##
+  ## `uiScale` is `ScreenLayout.uiScale`, and enlarges the `(px N)` sizes in
+  ## the layout text -- the only sizes here a caller cannot scale on its own.
+  ## Everything passed in above is in the driver's own unit already, so a
+  ## caller that scales its font has to scale `padding` and `gap` with it.
+  ##
   ## A layout that did not parse resolves to nothing.
   result = initTable[string, Rect]()
   if layout.error.len > 0: return
   place(layout.root, Rect(x: 0, y: 0, w: screenW, h: screenH),
-        lineHeight, padding, gap, result)
+        lineHeight, padding, gap, uiScale, result)
 
 proc hasCell(n: Node; name: string): bool =
   if n.kind == nkCell:

--- a/tests/configtest.nim
+++ b/tests/configtest.nim
@@ -64,6 +64,21 @@ block:
   equals("and all three are readable", c.note, "")
 
 block:
+  # A `(px N)` is logical, so the same config has to describe the same window
+  # on a display of any density: at 200% the sidebar takes twice the pixels
+  # and the editor keeps whatever that leaves.
+  let c = parsed("(config (layout (cols (sidebar (px 30)) (editor))))")
+  let normal = c.layout.resolve(100, 100, lineHeight = 10, padding = 0)
+  let dense = c.layout.resolve(100, 100, lineHeight = 10, padding = 0,
+                               uiScale = 200)
+  equals("a px size is logical", $normal["sidebar"].w & " -> " & $dense["sidebar"].w,
+         "30 -> 60")
+  equals("and the stretching neighbour gives way",
+         $normal["editor"].w & " -> " & $dense["editor"].w, "70 -> 40")
+  equals("the dense sidebar still starts at the left edge",
+         $dense["sidebar"].x & "," & $dense["editor"].x, "0,60")
+
+block:
   let c = parsed("(config (theme (bg \"#14141E\")) (layout (editor)))")
   check("theme before layout", c.layout.cell("editor"))
   equals("and both took effect", $c.theme.bg, "20,20,30")


### PR DESCRIPTION
On Windows the display scale was set up and then immediately undone. ShowWindow sends WM_SIZE synchronously, and that handler queues a WindowMetricsEvent stamped with gUiScale -- still the 100 default, since currentUiScale() only ran a few lines further down. An app got the real scale back from createWindow, opened its fonts with it, and then read that stale event on its first frame and reopened every font unscaled. The scale is now seeded before the window exists, the way x11_driver already does it, and whatever creation queued gets the final answer.

With the fonts right, the (px N) sizes in a layout were left: a 200px sidebar is a third of its width on a 300% display, which wrapped paths after four characters. `resolve` takes a `uiScale` and enlarges them -- they are the only sizes there that a caller cannot scale on its own, coming out of the config text rather than the call. focim scales the padding and the gap it passes with the same helper its fonts use.