### PR TITLE
terminal: the colors a program asks for

### DIFF
--- a/apps/focim.nim
+++ b/apps/focim.nim
@@ -1759,6 +1759,10 @@ proc main =
     else: os.getCurrentDir())
   var lastCurrent = current
   var lastTitle = ""
+  # What the tab list was last scrolled to show, and whether it was the one
+  # being typed in at the time -- see the tab list block in the loop.
+  var shownTab = -1
+  var tabsHadFocus = false
 
   var focus = "editor"
   # Where the pointer was last seen. A wheel event carries its delta in `x`
@@ -2176,6 +2180,29 @@ proc main =
     # the list is hidden, because Ctrl+W still edits its buffer.
     if tabs.names != displayNames(buffers): renderTabs(tabs, buffers)
     decorateTabs(tabs, buffers, current)
+    # The list follows the active tab, which is chosen anywhere but here:
+    # Ctrl+W, a file opened from the explorer, a jump to a definition. While
+    # the list has the focus its own caret leads and the view goes with it --
+    # the arrows are for reading down the list, and a list that snapped back
+    # after every one of them could not be read. The moment it has not, the
+    # row that matters is the active tab again, so it goes to the middle,
+    # where it can be seen along with what is around it.
+    #
+    # The caret goes with it, rather than the view alone: it is where the
+    # arrow keys will start from when the list is next stepped into, and
+    # leaving it behind would make the first keystroke there jump the view
+    # back to wherever the list had been left.
+    let tabsFocused = focus == "tabs"
+    if "tabs" in cells and
+       (current != shownTab or tabsFocused != tabsHadFocus):
+      if not tabsFocused and current < tabs.names.len:
+        tabs.ed.gotoLine(current + 1, 0)
+        tabs.ed.centerLine(current)
+      # Not counted as done until the list has been drawn once: before that it
+      # has no height, so there is no middle to put anything in yet.
+      if tabs.ed.span > 0:
+        shownTab = current
+        tabsHadFocus = tabsFocused
     var tabAct = EditAction(kind: noAction)
     if "tabs" in cells:
       tabAct = tabs.ed.draw(e, cells["tabs"], focus == "tabs")

--- a/src/widgets/ansi.nim
+++ b/src/widgets/ansi.nim
@@ -1,21 +1,23 @@
 ## ANSI escape sequences -- what a program asks for, as a token class.
 ##
-## A terminal panel is not a terminal: it has no grid, no addressable cursor
-## and no program that believes it is talking to one. What it does have is
-## output from tools that colour it, and those tools ask for colour and
-## nothing else. Measured on the two that get read most here::
+## The panel runs its programs on a pty (see `pty`), so they believe they are
+## talking to a terminal and say everything they would say to one. Most of
+## that is colour. Measured on what actually gets read here::
 ##
-##   git log -p (color.ui=always)  ^[[m ^[[1m ^[[31m ^[[32m ^[[33m ^[[36m
-##   nim c --colors:on             ^[[0m ^[[1m ^[[31m ^[[36m
-##   ls --color=always             ^[[0m ^[[01;34m
+##   git log -p         ^[[m ^[[1m ^[[31m ^[[32m ^[[33m ^[[36m ^[[1;36m
+##   nim c --colors:on  ^[[0m ^[[1m ^[[31m ^[[36m
+##   a progress meter   \r ^[[K, and ^[[A when it counts several things
 ##
-## Not one cursor movement between them. So this reads SGR -- `ESC [ ... m`,
-## the colour -- and *swallows* everything else, which is the other half of
-## the job: an escape nobody understands must disappear rather than come out
-## as `^[[?25h` in the middle of a line.
+## So this reads two things and *swallows* the rest, which is as much of the
+## job as either: an escape nobody has an answer for must disappear rather
+## than come out as `^[[?25h` in the middle of a line.
 ##
-## What comes out is clean text plus the runs of it that carry a colour, ready
-## for `SynEdit.appendOutput` to insert and `setStyleRange` to paint.
+## The first is SGR -- `ESC [ ... m` -- as a token class, which is how the
+## rest of this program already says what colour something is.
+##
+## The second is where the cursor went, and only as far as a meter takes it.
+## What that needs is not a screen but the last few rows of one, still open to
+## being drawn on again; that is `TermScreen`, at the bottom of this file.
 
 import theme
 
@@ -172,45 +174,131 @@ proc escapeEnd(s: string; start: int): int =
     # Two bytes: `ESC 7`, `ESC M`, `ESC =`.
     return i + 1
 
-proc parseAnsi*(st: var AnsiState; input: string; tabSize: int;
-                text: var string; runs: var seq[AnsiRun]): bool =
-  ## Append the printable part of `input` to `text` and the colors of it to
-  ## `runs`. True when `input` carried any SGR at all -- which is what tells
-  ## the caller whether the colors here are the program's, or whether the
-  ## highlighter should go on guessing them from the shape of the lines.
-  ##
-  ## `text` comes out normalised the way `rawInsert` would normalise it --
-  ## tabs expanded, carriage returns dropped -- so that a run counts the same
-  ## bytes the buffer ends up holding and the two cannot drift apart.
-  result = false
-  let s = if st.partial.len == 0: input else: st.partial & input
-  st.partial.setLen 0
-  var cur = st.tokenClass
-  var runLen = 0
+# ---------------------------------------------------------------------------
+# The screen a progress bar draws on
+# ---------------------------------------------------------------------------
 
-  template flush() =
-    if runLen > 0:
-      runs.add AnsiRun(len: runLen, tc: cur)
-      runLen = 0
+## Everything above turns bytes into color. What follows turns the *movements*
+## into rows, and only as far as a progress bar needs:
+##
+##   \r      back to the first column, and print the line again
+##   \b      one column back
+##   ESC[K   rub out the rest of the line
+##   ESC[nA  up n rows, for a meter that draws on several
+##   ESC[nG  to column n
+##
+## That is what `curl`, `git clone`, `cargo`, `pip` and `docker` do, and it is
+## all they do. What it is *not* is a terminal: there is no addressable screen
+## here, only the last few rows of output, still open to being rewritten. A
+## row that falls off the end of that tail is final, and goes into the buffer
+## as text like any other. A program that tries to draw further up than the
+## tail reaches -- a full-screen one, which is the other kind -- finds the top
+## of it and draws there instead, which will look wrong. That is the trade:
+## the tools that get read in a panel are the ones that print and stop.
 
-  template emit(c: char) =
-    text.add c
-    inc runLen
+const LiveRows* = 16
+  ## How many rows stay open to rewriting. A meter uses one, or one per thing
+  ## it is counting; sixteen is past anything that is still a meter, and the
+  ## cost of the tail is that it is redrawn whenever it changes.
 
+type
+  TermCell* = object
+    ## One column. `n` of 0 is a column never written to, which reads as a
+    ## space -- a program may jump past the end of a row and print there.
+    b: array[4, char]
+    n: uint8
+    tc*: TokenClass
+
+  TermRow* = object
+    cells*: seq[TermCell]
+    colored*: bool     ## whether the program asked for any color in this row.
+                       ## A row that did not is still the highlighter's, which
+                       ## is what keeps a plain `git diff` green and red.
+
+  TermScreen* = object
+    ## The live tail, and the parser state that feeds it.
+    rows*: seq[TermRow]
+    cy*, cx*: int
+    st: AnsiState
+
+proc initTermScreen*(): TermScreen =
+  TermScreen(rows: @[TermRow()], cy: 0, cx: 0, st: initAnsiState())
+
+proc text*(r: TermRow): string =
+  ## The row as bytes, with the columns nobody wrote to as spaces and the run
+  ## of them at the end left off -- a meter that shortens its line should not
+  ## leave the buffer holding the width of the longest it ever was.
+  var last = -1
+  for i, c in r.cells:
+    if c.n > 0'u8: last = i
+  for i in 0 .. last:
+    let c = r.cells[i]
+    if c.n == 0'u8: result.add ' '
+    else:
+      for k in 0 ..< c.n.int: result.add c.b[k]
+
+proc runs*(r: TermRow): seq[AnsiRun] =
+  ## The row's colors, as runs over the bytes `text` produced.
+  var last = -1
+  for i, c in r.cells:
+    if c.n > 0'u8: last = i
+  var cur = TokenClass.None
+  var n = 0
+  for i in 0 .. last:
+    let c = r.cells[i]
+    let tc = if c.n == 0'u8: TokenClass.None else: c.tc
+    let w = if c.n == 0'u8: 1 else: c.n.int
+    if tc != cur and n > 0:
+      result.add AnsiRun(len: n, tc: cur)
+      n = 0
+    cur = tc
+    n += w
+  if n > 0: result.add AnsiRun(len: n, tc: cur)
+
+proc put(sc: var TermScreen; bytes: string; tc: TokenClass) =
+  ## One grapheme into the column the cursor is on, and the cursor moves past
+  ## it. A row grows to reach a column that was jumped to.
+  if bytes.len == 0 or bytes.len > 4: return
+  while sc.rows.len <= sc.cy: sc.rows.add TermRow()
+  if sc.cx < 0: sc.cx = 0
+  while sc.rows[sc.cy].cells.len <= sc.cx: sc.rows[sc.cy].cells.add TermCell()
+  var cell = TermCell(n: uint8(bytes.len), tc: tc)
+  for i, ch in bytes: cell.b[i] = ch
+  sc.rows[sc.cy].cells[sc.cx] = cell
+  if tc != TokenClass.None: sc.rows[sc.cy].colored = true
+  inc sc.cx
+
+proc feed*(sc: var TermScreen; input: string; tabSize: int): seq[TermRow] =
+  ## Take a chunk of what a program printed. What comes back is the rows that
+  ## have been pushed out of the live tail by it and can no longer be drawn
+  ## on -- they are final, in the order they were printed.
+  result = @[]
+  let s = if sc.st.partial.len == 0: input else: sc.st.partial & input
+  sc.st.partial.setLen 0
   var i = 0
+
+  template row(): untyped = sc.rows[sc.cy]
+
+  template ensureRow() =
+    while sc.rows.len <= sc.cy: sc.rows.add TermRow()
+
   while i < s.len:
     let c = s[i]
-    if c == '\e':
+    case c
+    of '\e':
       let e = escapeEnd(s, i)
       if e < 0:
-        # Cut in half. Keep it for the next chunk -- unless it has grown past
-        # anything a real sequence could be, in which case it was never one.
-        if s.len - i <= MaxPartial: st.partial = s[i .. ^1]
+        # Cut in half by the end of the chunk. Keep it for the next one --
+        # unless it has grown past anything a real sequence could be, in which
+        # case it was never one and waiting for its end would swallow the file.
+        if s.len - i <= MaxPartial: sc.st.partial = s[i .. ^1]
         break
-      if s[i+1] == '[' and s[e-1] == 'm':
-        result = true
+      if s[i+1] == '[':
+        # Read the parameters once; which of them matter depends on the final
+        # byte, and everything whose final byte is not named here is swallowed.
         var params: seq[int] = @[]
         var n = -1
+        var private = false
         for k in i+2 ..< e-1:
           case s[k]
           of '0'..'9': n = (if n < 0: 0 else: n) * 10 + (ord(s[k]) - ord('0'))
@@ -218,26 +306,71 @@ proc parseAnsi*(st: var AnsiState; input: string; tabSize: int;
             params.add (if n < 0: 0 else: n)
             n = -1
           else:
-            # A private sequence: `ESC[>4m` sets something about keys, not
-            # about color, and must not be read as one.
-            params.setLen 0
-            n = -1
+            # `ESC[?25l`, `ESC[>4m`: a private sequence, about something other
+            # than what is on the screen.
+            private = true
             break
         if n >= 0: params.add n
-        let before = st.tokenClass
-        st.applySgr(params)
-        if st.tokenClass != before:
-          flush()
-          cur = st.tokenClass
+        let p0 = if params.len > 0: params[0] else: 0
+        let count = max(p0, 1)
+        if not private:
+          case s[e-1]
+          of 'm': sc.st.applySgr(params)
+          of 'A': sc.cy = max(0, sc.cy - count)
+          of 'B': sc.cy += count; ensureRow()
+          of 'C': sc.cx += count
+          of 'D': sc.cx = max(0, sc.cx - count)
+          of 'G': sc.cx = max(0, count - 1)
+          of 'd': sc.cy = max(0, count - 1); ensureRow()
+          of 'K':
+            ensureRow()
+            case p0
+            of 1:
+              for k in 0 .. min(sc.cx, row.cells.high): row.cells[k] = TermCell()
+            of 2: row.cells.setLen 0
+            else:
+              if sc.cx < row.cells.len: row.cells.setLen sc.cx
+          else: discard
       i = e
-    else:
-      # The same filtering `rawInsert` does, done here so that a run's length
-      # is the number of bytes the buffer will hold.
-      case c
-      of '\C': discard
-      of '\t':
-        for j in 1..tabSize: emit ' '
-      of '\0': emit '_'
-      else: emit c
+    of '\c':
+      sc.cx = 0
       inc i
-  flush()
+    of '\L':
+      # A terminal's line feed goes *down* and stays in its column; the
+      # carriage return that puts it back at the left is a separate character,
+      # and on a pty the driver supplies it. This is not a terminal, and the
+      # panel it writes into means "next line" by a newline -- so this does
+      # both. The `\r\n` a pty actually delivers then simply says it twice.
+      inc sc.cy
+      sc.cx = 0
+      ensureRow()
+      inc i
+    of '\b':
+      sc.cx = max(0, sc.cx - 1)
+      inc i
+    of '\t':
+      for j in 1..tabSize: sc.put(" ", sc.st.tokenClass)
+      inc i
+    of '\0':
+      sc.put("_", sc.st.tokenClass)
+      inc i
+    else:
+      # One grapheme, however many bytes it took to write it. A rune that the
+      # end of the chunk cut in half waits for the rest, the same as an escape
+      # sequence does -- half of one in the buffer would draw as a box.
+      var w = 1
+      if ord(c) >= 0xF0: w = 4
+      elif ord(c) >= 0xE0: w = 3
+      elif ord(c) >= 0xC0: w = 2
+      if i + w > s.len:
+        if s.len - i <= MaxPartial: sc.st.partial = s[i .. ^1]
+        break
+      sc.put(s[i ..< i+w], sc.st.tokenClass)
+      i += w
+
+  # Whatever the cursor can no longer reach is final.
+  if sc.rows.len > LiveRows:
+    let done = sc.rows.len - LiveRows
+    result = sc.rows[0 ..< done]
+    sc.rows = sc.rows[done .. ^1]
+    sc.cy = max(0, sc.cy - done)

--- a/src/widgets/ansi.nim
+++ b/src/widgets/ansi.nim
@@ -1,0 +1,243 @@
+## ANSI escape sequences -- what a program asks for, as a token class.
+##
+## A terminal panel is not a terminal: it has no grid, no addressable cursor
+## and no program that believes it is talking to one. What it does have is
+## output from tools that colour it, and those tools ask for colour and
+## nothing else. Measured on the two that get read most here::
+##
+##   git log -p (color.ui=always)  ^[[m ^[[1m ^[[31m ^[[32m ^[[33m ^[[36m
+##   nim c --colors:on             ^[[0m ^[[1m ^[[31m ^[[36m
+##   ls --color=always             ^[[0m ^[[01;34m
+##
+## Not one cursor movement between them. So this reads SGR -- `ESC [ ... m`,
+## the colour -- and *swallows* everything else, which is the other half of
+## the job: an escape nobody understands must disappear rather than come out
+## as `^[[?25h` in the middle of a line.
+##
+## What comes out is clean text plus the runs of it that carry a colour, ready
+## for `SynEdit.appendOutput` to insert and `setStyleRange` to paint.
+
+import theme
+
+type
+  AnsiRun* = object
+    ## `len` bytes of the emitted text are `tc`. Runs are consecutive and
+    ## cover all of it, so a walk over them needs no positions of its own.
+    len*: int
+    tc*: TokenClass
+
+  AnsiState* = object
+    ## What survives between two chunks of output. A program's colour stays
+    ## in force until it says otherwise, and a `read` can cut an escape in
+    ## half, so neither can be worked out from a chunk alone.
+    color: int          ## the ANSI color in force, 0..15; -1 is the default
+    bold: bool          ## `ESC[1m`, which makes a color its bright twin
+    partial: string     ## an escape sequence cut by the end of a chunk
+
+const
+  MaxPartial = 256
+    ## How much of an unfinished escape sequence is worth keeping. A real one
+    ## is a dozen bytes; anything longer is a lone `ESC` in binary output, and
+    ## holding on to the rest of the file waiting for it to end is how a
+    ## terminal that met a `.tar` stops showing anything at all.
+
+  Xterm: array[16, tuple[r, g, b: int]] = [
+    ## What the sixteen colors *are*, as xterm draws them. Only for measuring
+    ## against: a program that asks for `38;2;215;119;87` picked that value
+    ## with a terminal in mind, so the nearest of these says which of the
+    ## sixteen it meant, and the theme then says what that one looks like here.
+    (0, 0, 0), (205, 0, 0), (0, 205, 0), (205, 205, 0),
+    (0, 0, 238), (205, 0, 205), (0, 205, 205), (229, 229, 229),
+    (127, 127, 127), (255, 0, 0), (0, 255, 0), (255, 255, 0),
+    (92, 92, 255), (255, 0, 255), (0, 255, 255), (255, 255, 255)]
+
+  AnsiClass*: array[16, TokenClass] = [
+    ## The sixteen, as token classes. `Red`, `Green` and `Yellow` are the ones
+    ## the console highlighter already guesses with -- a `-` line, a `+` line,
+    ## a `warning:` -- and a theme that has chosen a shade for those has chosen
+    ## it for these too. One knob, not two that must be kept looking alike.
+    TokenClass.Black, TokenClass.Red, TokenClass.Green, TokenClass.Yellow,
+    TokenClass.Blue, TokenClass.Magenta, TokenClass.Cyan, TokenClass.White,
+    TokenClass.BrightBlack, TokenClass.BrightRed, TokenClass.BrightGreen,
+    TokenClass.BrightYellow, TokenClass.BrightBlue, TokenClass.BrightMagenta,
+    TokenClass.BrightCyan, TokenClass.BrightWhite]
+
+proc initAnsiState*(): AnsiState =
+  AnsiState(color: -1, bold: false, partial: "")
+
+proc tokenClass(st: AnsiState): TokenClass =
+  ## The class the state currently paints in. Bold makes a color its bright
+  ## twin, which is what a terminal has done with `ESC[1m` since the hardware
+  ## had one intensity and eight wires: `ls` says `01;34` and means bright
+  ## blue. Bold on its own is the same thing said about the default color, and
+  ## it is worth honouring: `git log` sets it and nothing else on the
+  ## `commit`/`diff --git` headers, and dropping it would leave the one line
+  ## the output is organised around looking like all the others.
+  if st.color < 0: (if st.bold: TokenClass.BrightWhite else: TokenClass.None)
+  elif st.bold and st.color < 8: AnsiClass[st.color + 8]
+  else: AnsiClass[st.color]
+
+proc nearest(r, g, b: int): int =
+  ## Which of the sixteen a color is closest to, by plain distance in RGB.
+  ## Good enough for the job: the question is only ever which *name* a program
+  ## had in mind, and the answers are far apart.
+  result = 0
+  var best = high(int)
+  for i in 0 ..< 16:
+    let dr = r - Xterm[i].r
+    let dg = g - Xterm[i].g
+    let db = b - Xterm[i].b
+    let d = dr*dr + dg*dg + db*db
+    if d < best:
+      best = d
+      result = i
+
+proc cubeColor(idx: int): int =
+  ## A 256-color index as one of the sixteen. 0..15 are the sixteen already;
+  ## 16..231 are a 6x6x6 cube; 232..255 a ramp of greys.
+  if idx < 16: idx
+  elif idx < 232:
+    let n = idx - 16
+    template level(v: int): int = (if v == 0: 0 else: 55 + 40 * v)
+    nearest(level(n div 36), level((n div 6) mod 6), level(n mod 6))
+  else:
+    let v = 8 + 10 * (idx - 232)
+    nearest(v, v, v)
+
+proc applySgr(st: var AnsiState; params: seq[int]) =
+  ## `ESC [ ... m`. Everything that is not a foreground color is read past:
+  ## backgrounds have nowhere to go in a theme whose cells carry one class
+  ## each, and italics and underlines are not worth a class apiece.
+  if params.len == 0:
+    st.color = -1
+    st.bold = false
+    return
+  var i = 0
+  while i < params.len:
+    let p = params[i]
+    case p
+    of 0: st.color = -1; st.bold = false
+    of 1: st.bold = true
+    of 22: st.bold = false
+    of 30..37: st.color = p - 30
+    of 39: st.color = -1
+    of 90..97: st.color = p - 90 + 8
+    of 38:
+      # `38;5;n` is one of 256, `38;2;r;g;b` a color in full. Both are read to
+      # the end whether or not they are used, or the numbers behind them would
+      # come out as separate attributes.
+      if i + 1 < params.len and params[i+1] == 5:
+        if i + 2 < params.len: st.color = cubeColor(params[i+2])
+        i += 2
+      elif i + 1 < params.len and params[i+1] == 2:
+        if i + 4 < params.len:
+          st.color = nearest(params[i+2], params[i+3], params[i+4])
+        i += 4
+    of 48:
+      # A background, which is swallowed -- but its arguments have to be
+      # stepped over all the same.
+      if i + 1 < params.len and params[i+1] == 5: i += 2
+      elif i + 1 < params.len and params[i+1] == 2: i += 4
+    else: discard
+    inc i
+
+proc escapeEnd(s: string; start: int): int =
+  ## One past the end of the escape sequence at `start`, or -1 when the string
+  ## runs out first and the rest of it has to wait for the next chunk.
+  ##
+  ## Only enough of the shape of each kind to know where it stops: what is in
+  ## the middle matters for `ESC [ ... m` alone, and the caller reads that off
+  ## the same bytes.
+  var i = start + 1
+  if i >= s.len: return -1
+  case s[i]
+  of '[':
+    # CSI: parameter bytes, then intermediates, then one final byte.
+    inc i
+    while i < s.len and s[i] in {'\x30'..'\x3F'}: inc i
+    while i < s.len and s[i] in {'\x20'..'\x2F'}: inc i
+    if i >= s.len: return -1
+    return i + 1
+  of ']', 'P', 'X', '^', '_':
+    # A string sequence -- OSC and friends -- ending at BEL or at ST (`ESC \`).
+    inc i
+    while i < s.len:
+      if s[i] == '\a': return i + 1
+      if s[i] == '\e':
+        if i + 1 >= s.len: return -1
+        if s[i+1] == '\\': return i + 2
+      inc i
+    return -1
+  else:
+    # Two bytes: `ESC 7`, `ESC M`, `ESC =`.
+    return i + 1
+
+proc parseAnsi*(st: var AnsiState; input: string; tabSize: int;
+                text: var string; runs: var seq[AnsiRun]): bool =
+  ## Append the printable part of `input` to `text` and the colors of it to
+  ## `runs`. True when `input` carried any SGR at all -- which is what tells
+  ## the caller whether the colors here are the program's, or whether the
+  ## highlighter should go on guessing them from the shape of the lines.
+  ##
+  ## `text` comes out normalised the way `rawInsert` would normalise it --
+  ## tabs expanded, carriage returns dropped -- so that a run counts the same
+  ## bytes the buffer ends up holding and the two cannot drift apart.
+  result = false
+  let s = if st.partial.len == 0: input else: st.partial & input
+  st.partial.setLen 0
+  var cur = st.tokenClass
+  var runLen = 0
+
+  template flush() =
+    if runLen > 0:
+      runs.add AnsiRun(len: runLen, tc: cur)
+      runLen = 0
+
+  template emit(c: char) =
+    text.add c
+    inc runLen
+
+  var i = 0
+  while i < s.len:
+    let c = s[i]
+    if c == '\e':
+      let e = escapeEnd(s, i)
+      if e < 0:
+        # Cut in half. Keep it for the next chunk -- unless it has grown past
+        # anything a real sequence could be, in which case it was never one.
+        if s.len - i <= MaxPartial: st.partial = s[i .. ^1]
+        break
+      if s[i+1] == '[' and s[e-1] == 'm':
+        result = true
+        var params: seq[int] = @[]
+        var n = -1
+        for k in i+2 ..< e-1:
+          case s[k]
+          of '0'..'9': n = (if n < 0: 0 else: n) * 10 + (ord(s[k]) - ord('0'))
+          of ';':
+            params.add (if n < 0: 0 else: n)
+            n = -1
+          else:
+            # A private sequence: `ESC[>4m` sets something about keys, not
+            # about color, and must not be read as one.
+            params.setLen 0
+            n = -1
+            break
+        if n >= 0: params.add n
+        let before = st.tokenClass
+        st.applySgr(params)
+        if st.tokenClass != before:
+          flush()
+          cur = st.tokenClass
+      i = e
+    else:
+      # The same filtering `rawInsert` does, done here so that a run's length
+      # is the number of bytes the buffer will hold.
+      case c
+      of '\C': discard
+      of '\t':
+        for j in 1..tabSize: emit ' '
+      of '\0': emit '_'
+      else: emit c
+      inc i
+  flush()

--- a/src/widgets/pty.nim
+++ b/src/widgets/pty.nim
@@ -1,0 +1,164 @@
+## A pseudo-terminal, so that a program believes a person is reading it.
+##
+## Everything a command-line tool decides about how to talk -- whether to
+## color, whether `git log` decorates, whether a progress meter is worth
+## drawing -- it decides by asking whether its output is a terminal. Answering
+## that with a pipe and then arguing with the answer through environment
+## variables works one tool at a time and one setting at a time. A pty answers
+## yes once, and every tool believes it.
+##
+## What comes back is a terminal's worth of escape sequences, of which this
+## panel understands color and the handful of movements a progress bar makes.
+## The rest is swallowed (see `ansi`), so a full-screen program will look
+## wrong here -- that is the trade, and it is the right way round: the tools
+## that get read here are the ones that print and stop.
+##
+## POSIX only. On Windows the terminal keeps its pipes, since the equivalent
+## there is ConPTY and a different piece of work.
+
+when defined(posix):
+  import std/[posix, strtabs]
+
+  const ptyHeader =
+    when defined(macosx) or defined(openbsd) or defined(netbsd): "<util.h>"
+    elif defined(freebsd) or defined(dragonfly): "<libutil.h>"
+    else: "<pty.h>"
+
+  when not (defined(macosx) or defined(android)):
+    {.passL: "-lutil".}
+
+  type
+    Winsize {.importc: "struct winsize", header: "<sys/ioctl.h>",
+              final, pure.} = object
+      ws_row, ws_col, ws_xpixel, ws_ypixel: cushort
+
+  proc forkpty(amaster: ptr cint; name: cstring; termp: pointer;
+               winp: ptr Winsize): Pid {.importc, header: ptyHeader.}
+
+  proc exitNow(code: cint) {.importc: "_exit", header: "<unistd.h>",
+                             noreturn.}
+    ## `quit` would run this process's exit handlers -- in a forked child that
+    ## means flushing its parent's buffers and tearing down state the parent
+    ## still owns. `_exit` leaves all of it alone.
+
+  var TIOCSWINSZ {.importc, header: "<sys/ioctl.h>".}: uint
+
+  type
+    Pty* = object
+      master*: cint    ## our end; -1 when nothing is running
+      pid*: Pid        ## the child, which `forkpty` made a session leader, so
+                       ## its process *group* is this same number -- which is
+                       ## what a signal meant for "the program in front" goes to
+      alive*: bool
+      exitCode*: int   ## meaningful once `alive` has gone false
+
+  proc setSize*(p: Pty; cols, rows: int) =
+    ## Tell the program how wide it may draw. Without this it believes the
+    ## 80x24 of a terminal nobody has owned since 1978, and wraps its output
+    ## somewhere other than where the panel does.
+    if p.master < 0: return
+    var ws = Winsize(ws_row: cushort(max(rows, 1)), ws_col: cushort(max(cols, 1)))
+    discard ioctl(p.master, TIOCSWINSZ, addr ws)
+
+  proc envToSeq(env: StringTableRef): seq[string] =
+    result = @[]
+    if env != nil:
+      for k, v in env: result.add k & "=" & v
+
+  proc startPty*(bin: string; args: seq[string]; workDir: string;
+                 env: StringTableRef; cols, rows: int): Pty =
+    ## Run `bin` on a terminal of its own. Everything the child will need is
+    ## built before the fork: between the fork and the exec it may not
+    ## allocate, because the allocator it inherited belongs to a thread that
+    ## did not come with it.
+    result = Pty(master: -1, pid: 0, alive: false)
+    var ws = Winsize(ws_row: cushort(max(rows, 1)),
+                     ws_col: cushort(max(cols, 1)))
+    var argv = allocCStringArray(@[bin] & args)
+    var envp = allocCStringArray(envToSeq(env))
+    var master: cint = -1
+    let pid = forkpty(addr master, nil, nil, addr ws)
+    if pid < 0:
+      deallocCStringArray(argv)
+      deallocCStringArray(envp)
+      return
+    if pid == 0:
+      # The child. `forkpty` has already given it the slave side as its
+      # controlling terminal and as all three standard descriptors.
+      if workDir.len > 0: discard chdir(workDir.cstring)
+      discard execvpe(argv[0], argv, envp)
+      exitNow(127)
+    deallocCStringArray(argv)
+    deallocCStringArray(envp)
+    result.master = master
+    result.pid = pid
+    result.alive = true
+
+  proc waitForOutput*(p: Pty; timeoutMs: int): bool =
+    ## True as soon as there is something to read, or the far end has gone.
+    ## The timeout is what lets the loop notice a request that arrives while
+    ## the program is quiet -- typed input, or Ctrl+C.
+    if p.master < 0: return false
+    var fds = default(TFdSet)
+    FD_ZERO(fds)
+    FD_SET(p.master, fds)
+    var tv = Timeval(tv_sec: posix.Time(timeoutMs div 1000),
+                     tv_usec: Suseconds((timeoutMs mod 1000) * 1000))
+    result = select(p.master + 1, addr fds, nil, nil, addr tv) == 1
+
+  proc readAvailable*(p: Pty; buf: var string): int =
+    ## What has arrived, which may be part of a line. When the child closes the
+    ## other end a pty reports `EIO` rather than an end of file, so anything
+    ## that is not a positive count means the same thing here: nothing more.
+    if p.master < 0: return 0
+    result = posix.read(p.master, addr buf[0], buf.len)
+    if result < 0: result = 0
+
+  proc writeInput*(p: Pty; s: string) =
+    ## Typed text, on its way to the program. The terminal driver on the other
+    ## side is what turns it into a line for a program waiting on one.
+    if p.master < 0 or s.len == 0: return
+    var off = 0
+    while off < s.len:
+      let n = posix.write(p.master, addr s[off], s.len - off)
+      if n <= 0: break
+      off += n
+
+  proc interrupt*(p: Pty) =
+    ## What Ctrl+C means: a signal to the program in front, not to the one
+    ## process this panel happens to have started. `forkpty` made the child a
+    ## session leader, so its process group is its own pid, and the negative
+    ## of that reaches the whole pipeline it may have built.
+    if p.alive: discard kill(Pid(-p.pid), SIGINT)
+
+  proc terminate*(p: var Pty) =
+    ## Harder than `interrupt`, for a program that would not take the hint.
+    if not p.alive: return
+    discard kill(Pid(-p.pid), SIGHUP)
+    discard kill(Pid(-p.pid), SIGKILL)
+
+  proc running*(p: var Pty): bool =
+    ## Whether the child is still there, without waiting for it. Reaping it
+    ## here is what keeps it from becoming a zombie.
+    if not p.alive: return false
+    var status: cint = 0
+    let r = waitpid(p.pid, status, WNOHANG)
+    if r == p.pid:
+      p.alive = false
+      p.exitCode = if WIFEXITED(status): WEXITSTATUS(status)
+                   else: 128 + WTERMSIG(status)
+    result = p.alive
+
+  proc close*(p: var Pty): int {.discardable.} =
+    ## Waits for the child if it has not been waited for yet, and answers how
+    ## it went, the way a shell would report it.
+    if p.alive:
+      var status: cint = 0
+      discard waitpid(p.pid, status, 0)
+      p.alive = false
+      p.exitCode = if WIFEXITED(status): WEXITSTATUS(status)
+                   else: 128 + WTERMSIG(status)
+    if p.master >= 0:
+      discard posix.close(p.master)
+      p.master = -1
+    result = p.exitCode

--- a/src/widgets/pty.nim
+++ b/src/widgets/pty.nim
@@ -43,6 +43,19 @@ when defined(posix):
 
   var TIOCSWINSZ {.importc, header: "<sys/ioctl.h>".}: uint
 
+  when defined(macosx):
+    proc nsGetEnviron(): ptr cstringArray {.importc: "_NSGetEnviron",
+                                            header: "<crt_externs.h>".}
+      ## A macOS program does not name `environ` directly -- in a shared
+      ## library the symbol is not there to be named -- and this is the
+      ## accessor Apple provides in its place.
+
+    proc setEnviron(env: cstringArray) = nsGetEnviron()[] = env
+  else:
+    var environ {.importc: "environ".}: cstringArray
+
+    proc setEnviron(env: cstringArray) = environ = env
+
   type
     Pty* = object
       master*: cint    ## our end; -1 when nothing is running
@@ -86,7 +99,20 @@ when defined(posix):
       # The child. `forkpty` has already given it the slave side as its
       # controlling terminal and as all three standard descriptors.
       if workDir.len > 0: discard chdir(workDir.cstring)
-      discard execvpe(argv[0], argv, envp)
+      # `execvpe` takes the environment as an argument, which is tidier and is
+      # a GNU extension -- macOS and the BSDs have no such function. What every
+      # POSIX system does have is `execvp`, which reads the environment out of
+      # `environ`, and a child between the fork and the exec is free to point
+      # `environ` wherever it likes: the assignment is one pointer, allocating
+      # nothing, which is the only thing that may happen here.
+      #
+      # `execvp` searches `PATH` -- and it searches the *new* `PATH`, the one
+      # just installed, which is what `execvpe` did too. The search happens
+      # here rather than before the fork on purpose: it is the only way a
+      # relative command like `./configure` is looked for in `workDir`, which
+      # by now is where this process stands.
+      setEnviron(envp)
+      discard execvp(argv[0], argv)
       exitNow(127)
     deallocCStringArray(argv)
     deallocCStringArray(envp)

--- a/src/widgets/synedit.nim
+++ b/src/widgets/synedit.nim
@@ -208,6 +208,10 @@ type
     changed: bool
     readOnly*: int                  ## -1 = fully editable;
                                     ## >= 0 = positions <= readOnly are protected
+    ansiEnd: int                    ## one past the last position whose color
+                                    ## the *program* that printed it chose --
+                                    ## see `appendOutput` and `highlight`. 0
+                                    ## when nothing here was colored that way.
     # Bracket matching
     bracketA, bracketB: int
     # Underline (set by the app via underline())
@@ -1073,13 +1077,20 @@ proc highlightMarkdown(s: var SynEdit; first, last: int) =
     pos = lineEnd + 1
 
 proc highlight(s: var SynEdit; first, last: int; initialState: TokenClass) =
+  # Text a program colored itself is not the highlighter's to guess at. Below
+  # `ansiEnd` the classes are the ones the program asked for, and a pass over
+  # them would put back what the shape of the line suggests instead -- which
+  # is what would happen on the next keystroke, since an edit sends the
+  # incremental pass back to the start of the buffer.
+  let a = max(first, s.ansiEnd)
+  if a > last: return
   var g: GeneralTokenizer
   g.buf = addr s
   g.kind = low(TokenClass)
-  g.start = first
+  g.start = a
   g.length = 0
   g.state = initialState
-  g.pos = first
+  g.pos = a
   while g.pos <= last:
     getNextToken(g, s.lang)
     if g.length == 0: break
@@ -2231,6 +2242,7 @@ proc clear*(s: var SynEdit) =
   s.firstLineOffset = 0
   s.editLow = high(int)
   s.readOnly = -1
+  s.ansiEnd = 0
   s.clicks = 0
   s.undoIdx = 0
   s.cursorDim = (0, 0, 0)
@@ -2267,9 +2279,15 @@ proc saveToFile*(s: var SynEdit; filename: string) =
   writeFile(filename, s.fullText)
   s.changed = false
 
-proc appendOutput*(s: var SynEdit; text: string) =
+proc appendOutput*(s: var SynEdit; text: string; highlight = true) =
   ## Append text and mark everything as read-only up to the end.
   ## For terminal/console use: output is protected, user types after it.
+  ##
+  ## `highlight` is for a caller that already knows what color this text is:
+  ## a program that prints escape sequences has *said* what it wants, and the
+  ## highlighter guessing from the shape of the lines would only overrule it.
+  ## Such a caller passes `false`, paints the range itself with
+  ## `setStyleRange`, and says so with `markProgramColored`.
   ##
   ## The caret follows the output down only if it was at the end to begin
   ## with. A caret left further up is a reader's -- somebody is looking at
@@ -2289,7 +2307,7 @@ proc appendOutput*(s: var SynEdit; text: string) =
   # newline. Highlighting that one line would leave the output colorless --
   # and appending does not bump `version`, so the incremental pass that walks
   # the rest of a buffer never comes for this text either.
-  s.highlightFrom(start)
+  if highlight: s.highlightFrom(start)
   s.readOnly = s.len - 1
   if stay:
     s.gotoPos(oldCursor)
@@ -2298,6 +2316,18 @@ proc appendOutput*(s: var SynEdit; text: string) =
     # top line begins, which is why this pair may be put back as it was.
     s.firstLine = oldFirstLine
     s.firstLineOffset = oldFirstLineOffset
+
+proc setStyleRange*(s: var SynEdit; a, b: int; tc: TokenClass) =
+  ## Paint `[a..b]` in one class. For a caller that *knows* the color instead
+  ## of working it out from the text -- which is what reading it out of a
+  ## program's escape sequences amounts to.
+  for i in max(a, 0) .. min(b, s.len - 1): s.setCellStyle(i, tc)
+
+proc markProgramColored*(s: var SynEdit; upTo: int) =
+  ## Everything below `upTo` carries colors that arrived with the text, and
+  ## the highlighter is to keep its hands off them from here on. Output only
+  ## ever grows at the end, so one mark is enough to say it for all of it.
+  if upTo > s.ansiEnd: s.ansiEnd = upTo
 
 proc setLabel*(s: var SynEdit; text: string) =
   ## Set text and make the entire buffer read-only. For labels and status bars.

--- a/src/widgets/synedit.nim
+++ b/src/widgets/synedit.nim
@@ -2317,6 +2317,40 @@ proc appendOutput*(s: var SynEdit; text: string; highlight = true) =
     s.firstLine = oldFirstLine
     s.firstLineOffset = oldFirstLineOffset
 
+proc charSize*(s: SynEdit): tuple[w, h: int] =
+  ## How wide and tall one character is, for a caller that has to think in
+  ## characters rather than pixels -- a terminal telling a program how much
+  ## room it has. Measured on `M`, which in a monospaced family is every
+  ## character, and in one that is not is at least an honest upper bound.
+  (max(1, measureText(s.font, "M").w), max(1, fontLineSkip(s.font)))
+
+proc truncateOutput*(s: var SynEdit; at: int) =
+  ## Drop everything from `at` to the end. What a progress meter needs: it
+  ## draws its line again every time it moves, and the honest way to show that
+  ## is to take the previous drawing back off rather than to leave a hundred
+  ## of them stacked up.
+  ##
+  ## Not an edit anybody can undo -- output is not something the reader typed,
+  ## and a meter would otherwise fill the undo stack at its refresh rate.
+  let at = clamp(at, 0, s.len)
+  if at >= s.len: return
+  inc s.cacheId
+  s.noteEdit(at)
+  s.gotoPos(s.len)
+  s.prepareForEdit()          # which leaves all of it in `front`
+  var removed = 0
+  for i in at ..< s.front.len:
+    if s.front[i].c == '\L': inc removed
+  s.front.setLen at
+  s.cursor = at.Natural
+  s.numberOfLines = Natural(max(0, s.numberOfLines.int - removed))
+  if removed > 0: s.scroll(-removed)
+  if s.ansiEnd > at: s.ansiEnd = at
+  if s.readOnly >= at: s.readOnly = at - 1
+  if s.selected.b >= at or s.selected.a >= at: s.selected = (-1, -1)
+  s.currentLine = s.getLineFromOffset(s.cursor)
+  s.changed = true
+
 proc setStyleRange*(s: var SynEdit; a, b: int; tc: TokenClass) =
   ## Paint `[a..b]` in one class. For a caller that *knows* the color instead
   ## of working it out from the text -- which is what reading it out of a

--- a/src/widgets/synedit.nim
+++ b/src/widgets/synedit.nim
@@ -2359,6 +2359,40 @@ proc truncateOutput*(s: var SynEdit; at: int) =
   s.currentLine = s.getLineFromOffset(s.cursor)
   s.changed = true
 
+proc scrollToOutput*(s: var SynEdit; start: int) =
+  ## Leave the view at the top of what was printed from `start` on, which is
+  ## what a pager does and what the panel stopped doing when the pager was
+  ## taken away: a `git log` that follows its own output down leaves the
+  ## reader at the oldest commit in the repository, having sailed past the one
+  ## they asked about.
+  ##
+  ## Only when there is more of it than fits. Output already on screen needs no
+  ## scrolling, and scrolling it would push it up to make room for nothing.
+  ##
+  ## The caret stays where it is, off the bottom of the view. Moving it is what
+  ## brings the view back down, so the first key typed returns to the prompt.
+  if s.span <= 0: return
+  let start = clamp(start, 0, s.len)
+  let first = s.getLineFromOffset(start).int
+  let last = s.getLineFromOffset(s.len).int
+  if last - first < s.span: return
+  s.setFirstLine(first)
+
+proc revealCaret*(s: var SynEdit) =
+  ## Bring the view back to the caret, with it near the bottom -- which is
+  ## where a prompt is. The counterpart to `scrollToOutput`: having been left
+  ## up at the top of a long piece of output on purpose, the panel needs a way
+  ## back down, and the reader starting to type is it.
+  ##
+  ## Typing does not do this by itself. `render` chases the caret only when
+  ## something said it moved, and inserting a character where the caret
+  ## already is says nothing of the kind -- ordinarily there is no need,
+  ## because the caret was on screen to begin with.
+  if s.span <= 0: return
+  if s.currentLine >= s.firstLine and s.currentLine < s.firstLine + s.span - 1:
+    return
+  s.setFirstLine(s.currentLine.int - (s.span - 2))
+
 proc setStyleRange*(s: var SynEdit; a, b: int; tc: TokenClass) =
   ## Paint `[a..b]` in one class. For a caller that *knows* the color instead
   ## of working it out from the text -- which is what reading it out of a

--- a/src/widgets/synedit.nim
+++ b/src/widgets/synedit.nim
@@ -1216,7 +1216,15 @@ proc setFirstLine(s: var SynEdit; line: int) =
 
 proc noteEdit(s: var SynEdit; at: int) {.inline.} =
   ## Text was inserted or removed at `at`, so everything behind it has moved.
-  if at < s.editLow: s.editLow = at
+  ##
+  ## Unless there is nothing behind it. An edit at the very end of the buffer
+  ## -- which is every character a program prints -- moves nothing that was
+  ## already there, and claiming otherwise is expensive: `syncFirstLine`
+  ## answers the claim by working out where the top line of the view begins
+  ## all over again, and that is a walk from the start of the buffer. A
+  ## `git log -p` of forty thousand lines did nine and a half *billion* bytes
+  ## of walking that way, which is most of the seven seconds it took.
+  if at < s.len and at < s.editLow: s.editLow = at
 
 proc syncFirstLine(s: var SynEdit) =
   ## `firstLine` is a line number and `firstLineOffset` is the position that

--- a/src/widgets/synedit.nim
+++ b/src/widgets/synedit.nim
@@ -1345,6 +1345,25 @@ proc scrollTo*(s: var SynEdit; line: int) =
   ## by it.
   s.setFirstLine(line)
 
+proc centerLine*(s: var SynEdit; line: int) =
+  ## Put `line` halfway down the view and leave the caret alone.
+  ##
+  ## For a list whose lines are things rather than sentences, and where which
+  ## line is *the* one is decided somewhere other than here: the tab list
+  ## follows the editor, so its active row moves without anything in the list
+  ## having been touched. The middle is where a row can be read together with
+  ## the ones on either side of it, which is the point of showing the list at
+  ## all -- the top or the bottom edge shows the row and hides its
+  ## neighbourhood.
+  ##
+  ## Never past the end. A list shorter than the view stays where it is, and
+  ## the last line comes to rest on the bottom row instead of halfway up a
+  ## panel of blanks.
+  if s.span <= 0: return
+  let rows = max(1, s.span - 1)  # the last of `span` rows may be a sliver
+  let count = s.numberOfLines.int + 1  # `getLineCount` is not declared yet
+  s.setFirstLine(clamp(line - rows div 2, 0, max(0, count - rows)))
+
 proc wheelScroll*(s: var SynEdit; delta: int) =
   ## Scroll by one turn of the mouse wheel: three lines per notch, and the
   ## sign is the wheel's, so a positive delta scrolls towards the top of the

--- a/src/widgets/terminal.nim
+++ b/src/widgets/terminal.nim
@@ -228,13 +228,22 @@ var forcedEnv {.threadvar.}: StringTableRef
   ## the thread that owns it, and a global would make every proc that touches
   ## it un-GC-safe.
 
-proc colorEnv(): StringTableRef =
-  ## The environment a command is run in, with color asked for. Everything
-  ## here comes out of a pipe rather than a terminal, and a program that looks
-  ## before it colors -- which is all of them -- finds a pipe and turns color
-  ## off. These are the ways to say "do it anyway" that between them cover
-  ## what actually gets read in this panel; a variable the user already set is
-  ## left alone, since they have said something more specific than this has.
+proc panelEnv(): StringTableRef =
+  ## The environment a command is run in, told that a person is going to read
+  ## what it prints.
+  ##
+  ## Output here comes out of a pipe, and a program that looks before it
+  ## decides -- which is all of them -- finds a pipe and assumes it is talking
+  ## to another program: no color, and for `git`, no decorations either, since
+  ## both of those default to "only for a terminal". A pipe is the right answer
+  ## for the rest of what that question decides, though. Without a terminal
+  ## `git log` skips the pager, which is what makes it readable here at all,
+  ## and `git fetch` skips the progress meter, which redraws itself with
+  ## carriage returns this panel has nothing to do with yet. So the settings
+  ## are named one at a time rather than by claiming to be a terminal.
+  ##
+  ## A variable the user set themselves is left alone: they have said something
+  ## more specific than this has.
   if forcedEnv == nil:
     # Windows compares environment variable names without regard to case, so
     # a table that does not would answer "no" to `PATH` and add a second one.
@@ -245,12 +254,19 @@ proc colorEnv(): StringTableRef =
       if not forcedEnv.hasKey(key): forcedEnv[key] = value
     unless("CLICOLOR_FORCE", "1")
     unless("FORCE_COLOR", "1")
-    # Git has no environment variable for it, but it does take configuration
-    # from one, and `color.ui=always` is what `--color` sets.
+    # Git has no environment variable for either of these, but it does take
+    # configuration from one. `color.ui=always` is what `--color` sets, and
+    # `log.decorate=short` is what `auto` decides on for a terminal -- the
+    # `(HEAD -> master, origin/master)` that says where a commit sits, and the
+    # most obviously missing thing about a `git log` read through a pipe.
+    # Both lose to an option on the command line, so `--no-decorate` and
+    # `--no-color` still mean what they say.
     if not forcedEnv.hasKey("GIT_CONFIG_COUNT"):
-      forcedEnv["GIT_CONFIG_COUNT"] = "1"
-      forcedEnv["GIT_CONFIG_KEY_0"] = "color.ui"
-      forcedEnv["GIT_CONFIG_VALUE_0"] = "always"
+      const gitConfig = [("color.ui", "always"), ("log.decorate", "short")]
+      forcedEnv["GIT_CONFIG_COUNT"] = $gitConfig.len
+      for i, (key, value) in gitConfig:
+        forcedEnv["GIT_CONFIG_KEY_" & $i] = key
+        forcedEnv["GIT_CONFIG_VALUE_" & $i] = value
   result = forcedEnv
 
 proc execThreadProc() {.thread.} =
@@ -282,7 +298,7 @@ proc execThreadProc() {.thread.} =
           if not started:
             let (bin, args) = cmdToArgs(task.cmd)
             try:
-              p = startProcess(bin, task.cwd, args, env = colorEnv(),
+              p = startProcess(bin, task.cwd, args, env = panelEnv(),
                         options = {poStdErrToStdOut, poUsePath, poInteractive,
                                    poDaemon})
               started = true

--- a/src/widgets/terminal.nim
+++ b/src/widgets/terminal.nim
@@ -882,17 +882,36 @@ proc enterPressed(t: var Terminal): TermAction =
 # Update (poll background thread)
 # ---------------------------------------------------------------------------
 
-proc renderRow(t: var Terminal; r: TermRow; newline: bool) =
-  let start = t.ed.len
-  let txt = if newline: r.text & "\L" else: r.text
-  t.ed.appendOutput(txt, highlight = not r.colored)
-  if r.colored:
-    var pos = start
-    for run in r.runs:
-      if run.tc != TokenClass.None:
-        t.ed.setStyleRange(pos, pos + run.len - 1, run.tc)
-      pos += run.len
-    t.ed.markProgramColored(pos)
+proc renderRows(t: var Terminal; rows: openArray[TermRow];
+                trailingNewline: bool) =
+  ## The rows into the buffer, in as few insertions as it takes.
+  ##
+  ## One per row is what this obviously wants to be, and it is what makes a
+  ## megabyte of output quadratic: `appendOutput` works out which line the
+  ## caret ended up on, and that is a walk of the buffer, so a `git log -p`
+  ## of forty thousand rows walks it forty thousand times. Rows that agree
+  ## about whether the program colored them go in together, and since a
+  ## program either colors its output or does not, that is usually all of them.
+  var i = 0
+  while i < rows.len:
+    var j = i
+    while j + 1 < rows.len and rows[j+1].colored == rows[i].colored: inc j
+    var text = ""
+    for k in i .. j:
+      text.add rows[k].text
+      if trailingNewline or k < rows.high: text.add "\L"
+    let start = t.ed.len
+    t.ed.appendOutput(text, highlight = not rows[i].colored)
+    if rows[i].colored:
+      var pos = start
+      for k in i .. j:
+        for run in rows[k].runs:
+          if run.tc != TokenClass.None:
+            t.ed.setStyleRange(pos, pos + run.len - 1, run.tc)
+          pos += run.len
+        if trailingNewline or k < rows.high: inc pos    # past the line break
+      t.ed.markProgramColored(pos)
+    i = j + 1
 
 proc showOutput(t: var Terminal; raw: string) =
   ## What a program printed, as rows.
@@ -909,10 +928,9 @@ proc showOutput(t: var Terminal; raw: string) =
   ## in the output of something that never heard of color.
   let final = t.screen.feed(raw, t.ed.tabSize)
   t.ed.truncateOutput(t.liveStart)
-  for r in final: t.renderRow(r, newline = true)
+  t.renderRows(final, trailingNewline = true)
   t.liveStart = t.ed.len
-  for i, r in t.screen.rows:
-    t.renderRow(r, newline = i < t.screen.rows.high)
+  t.renderRows(t.screen.rows, trailingNewline = false)
 
 proc update*(t: var Terminal): bool =
   ## Takes whatever the thread running a program has said since the last look.
@@ -927,7 +945,20 @@ proc update*(t: var Terminal): bool =
   result = false
   if t.processRunning:
     if responses.peek > 0:
-      let resp = responses.recv()
+      # Everything that has piled up since the last look, not one piece of it.
+      # A program printing a megabyte hands it over in four-kilobyte pieces,
+      # and one piece per frame is hundreds of frames before the last of it is
+      # on screen -- the output would still be scrolling past long after the
+      # program had finished. Bounded, so that no single frame can be spent on
+      # an unbounded amount of it.
+      const MaxPerFrame = 256 * 1024
+      var text = ""
+      var over = false
+      while responses.peek > 0 and text.len < MaxPerFrame and not over:
+        let piece = responses.recv()
+        text.add piece.text
+        if piece.finished: over = true
+      let resp = ThreadReply(text: text, finished: over)
       if resp.text.len > 0:
         t.showOutput(resp.text)
       if resp.finished:

--- a/src/widgets/terminal.nim
+++ b/src/widgets/terminal.nim
@@ -18,6 +18,7 @@ when defined(windows): import std/winlean
 else: import std/posix
 import synedit
 import ansi
+when defined(posix): import pty
 import filesearch
 import ../uirelays/[coords, screen, input]
 
@@ -167,6 +168,11 @@ type
   ThreadTask = object
     cwd: string
     cmd: string
+    cols, rows: int   ## how wide and tall the panel is, in characters. A
+                      ## program asks its terminal this before it decides
+                      ## where to wrap, and answering 80x24 out of habit is
+                      ## how output ends up folded somewhere other than the
+                      ## edge it is being drawn against.
 
   ThreadReply = object
     text: string     ## output to append, may end mid-line
@@ -229,21 +235,18 @@ var forcedEnv {.threadvar.}: StringTableRef
   ## it un-GC-safe.
 
 proc panelEnv(): StringTableRef =
-  ## The environment a command is run in, told that a person is going to read
-  ## what it prints.
+  ## The environment a command is run in.
   ##
-  ## Output here comes out of a pipe, and a program that looks before it
-  ## decides -- which is all of them -- finds a pipe and assumes it is talking
-  ## to another program: no color, and for `git`, no decorations either, since
-  ## both of those default to "only for a terminal". A pipe is the right answer
-  ## for the rest of what that question decides, though. Without a terminal
-  ## `git log` skips the pager, which is what makes it readable here at all,
-  ## and `git fetch` skips the progress meter, which redraws itself with
-  ## carriage returns this panel has nothing to do with yet. So the settings
-  ## are named one at a time rather than by claiming to be a terminal.
+  ## On a pty there is almost nothing to say: the program asks whether it is
+  ## talking to a terminal, is told yes, and decides for itself to color and
+  ## to decorate -- and it obeys the user's own configuration while doing it,
+  ## which forcing `color.ui=always` down its throat did not.
   ##
-  ## A variable the user set themselves is left alone: they have said something
-  ## more specific than this has.
+  ## Two things still have to be said. `TERM`, because a terminal that does
+  ## not name itself is assumed to be incapable of anything. And that there is
+  ## to be no pager: `git log` on a terminal pipes itself through `less`, which
+  ## would sit in the panel waiting for a keypress on a screen nobody can see.
+  ## That is the one thing a pipe used to get right for free.
   if forcedEnv == nil:
     # Windows compares environment variable names without regard to case, so
     # a table that does not would answer "no" to `PATH` and add a second one.
@@ -252,33 +255,41 @@ proc panelEnv(): StringTableRef =
     for k, v in envPairs(): forcedEnv[k] = v
     template unless(key, value: string) =
       if not forcedEnv.hasKey(key): forcedEnv[key] = value
-    unless("CLICOLOR_FORCE", "1")
-    unless("FORCE_COLOR", "1")
-    # Git has no environment variable for either of these, but it does take
-    # configuration from one. `color.ui=always` is what `--color` sets, and
-    # `log.decorate=short` is what `auto` decides on for a terminal -- the
-    # `(HEAD -> master, origin/master)` that says where a commit sits, and the
-    # most obviously missing thing about a `git log` read through a pipe.
-    # Both lose to an option on the command line, so `--no-decorate` and
-    # `--no-color` still mean what they say.
-    if not forcedEnv.hasKey("GIT_CONFIG_COUNT"):
-      const gitConfig = [("color.ui", "always"), ("log.decorate", "short")]
-      forcedEnv["GIT_CONFIG_COUNT"] = $gitConfig.len
-      for i, (key, value) in gitConfig:
-        forcedEnv["GIT_CONFIG_KEY_" & $i] = key
-        forcedEnv["GIT_CONFIG_VALUE_" & $i] = value
+    when defined(posix):
+      unless("TERM", "xterm-256color")
+      # Not `unless`: a pager the user chose for their own terminal is exactly
+      # what must not run in here.
+      forcedEnv["PAGER"] = "cat"
+      forcedEnv["GIT_PAGER"] = "cat"
+    else:
+      # No pty here, so the arguing stands: a program that finds a pipe turns
+      # color off, and `git` turns its decorations off with it.
+      unless("CLICOLOR_FORCE", "1")
+      unless("FORCE_COLOR", "1")
+      if not forcedEnv.hasKey("GIT_CONFIG_COUNT"):
+        const gitConfig = [("color.ui", "always"), ("log.decorate", "short")]
+        forcedEnv["GIT_CONFIG_COUNT"] = $gitConfig.len
+        for i, (key, value) in gitConfig:
+          forcedEnv["GIT_CONFIG_KEY_" & $i] = key
+          forcedEnv["GIT_CONFIG_VALUE_" & $i] = value
   result = forcedEnv
 
 proc execThreadProc() {.thread.} =
-  var p: Process
+  when defined(posix):
+    var p: Pty
+  else:
+    var p: Process
   var started = false
   var chunk = newString(OutputChunk)
 
   template reap() =
-    ## The process is over: report how it went and say this is the last reply.
+    ## The program is over: report how it went and say this is the last reply.
     started = false
-    let exitCode = p.waitForExit()
-    p.close()
+    when defined(posix):
+      let exitCode = p.close()
+    else:
+      let exitCode = p.waitForExit()
+      p.close()
     if exitCode != 0:
       responses.send ThreadReply(
         text: "Process terminated with exitcode: " & $exitCode & "\L")
@@ -292,25 +303,50 @@ proc execThreadProc() {.thread.} =
         let task = requests.recv()
         if task.cmd == EndToken:
           if started:
-            p.terminate()
+            when defined(posix):
+              # A signal to the program in front, which is what Ctrl+C is. A
+              # program that means to catch it gets the chance to, and one that
+              # spawned others takes them with it.
+              p.interrupt()
+              # Give it a moment to go on its own before insisting.
+              var waited = 0
+              while p.running() and waited < 300:
+                os.sleep 20
+                inc waited, 20
+              if p.running(): p.terminate()
+            else:
+              p.terminate()
             reap()
         else:
           if not started:
             let (bin, args) = cmdToArgs(task.cmd)
-            try:
-              p = startProcess(bin, task.cwd, args, env = panelEnv(),
-                        options = {poStdErrToStdOut, poUsePath, poInteractive,
-                                   poDaemon})
-              started = true
-            except:
-              started = false
-              responses.send ThreadReply(text: getCurrentExceptionMsg())
-              responses.send ThreadReply(finished: true)
+            when defined(posix):
+              p = startPty(bin, args, task.cwd, panelEnv(),
+                           max(task.cols, 20), max(task.rows, 4))
+              started = p.alive
+              if not started:
+                responses.send ThreadReply(text: "cannot run: " & bin & "\L")
+                responses.send ThreadReply(finished: true)
+            else:
+              try:
+                p = startProcess(bin, task.cwd, args, env = panelEnv(),
+                          options = {poStdErrToStdOut, poUsePath, poInteractive,
+                                     poDaemon})
+                started = true
+              except:
+                started = false
+                responses.send ThreadReply(text: getCurrentExceptionMsg())
+                responses.send ThreadReply(finished: true)
           else:
-            p.inputStream.writeLine task.cmd
-            # Buffered: without this the process waits for input that is
-            # already sitting in this end of the pipe.
-            p.inputStream.flush()
+            when defined(posix):
+              # The line goes to the terminal driver, which is what a program
+              # waiting on one is waiting for.
+              p.writeInput(task.cmd & "\L")
+            else:
+              p.inputStream.writeLine task.cmd
+              # Buffered: without this the process waits for input that is
+              # already sitting in this end of the pipe.
+              p.inputStream.flush()
     if started:
       # Hand over whatever has arrived so far, even a part of a line -- that is
       # what makes a progress indicator move rather than appear at the end.
@@ -323,9 +359,9 @@ proc execThreadProc() {.thread.} =
           chunk.setLen n
           responses.send ThreadReply(text: chunk)
         else:
-          reap()      # end of the pipe
+          reap()      # the far end has gone
       elif not p.running:
-        reap()        # exited without closing the pipe (a child still holds it)
+        reap()        # exited without closing it (a child still holds it)
 
 var backgroundThread: Thread[void]
 createThread[void](backgroundThread, execThreadProc)
@@ -419,10 +455,16 @@ type
                         ## only a command here. In a terminal the same word is
                         ## a program's name, which is where it belongs -- see
                         ## `defaults` below.
-    ansi: AnsiState     ## the color a running program last asked for, and any
-                        ## escape sequence the end of a chunk cut in half --
-                        ## neither of which can be worked out from the next
-                        ## chunk on its own. See `showOutput`.
+    screen: TermScreen  ## the last few rows of what a program printed, still
+                        ## open to being drawn on again -- the color in force,
+                        ## an escape sequence the end of a chunk cut in half,
+                        ## and where the program left its cursor. See
+                        ## `showOutput`.
+    liveStart: int      ## the buffer offset those rows begin at. Everything
+                        ## before it is final; everything after is redrawn
+                        ## whenever the program moves.
+    cols, rows: int     ## the panel's size in characters, as last drawn, and
+                        ## what a program starting here is told it has.
     branch: string      ## cached result of `gitBranch`; see `insertPrompt`
     branchDir: string   ## the directory `branch` was read for. Anything else,
                         ## "" included, means the cache says nothing about the
@@ -451,6 +493,13 @@ proc getCommand(t: Terminal): string =
   result = ""
   for i in t.ed.readOnly + 1 ..< t.ed.len:
     result.add t.ed[i]
+
+proc endOutput(t: var Terminal) =
+  ## The program is gone, so the rows it could still have drawn on cannot be
+  ## drawn on any more. They stay where they are; what goes is the expectation
+  ## that anything will come back to them.
+  t.screen = initTermScreen()
+  t.liveStart = t.ed.len
 
 proc caretToEnd(t: var Terminal) =
   ## Put the caret back where typing goes. What a program printed is text like
@@ -598,6 +647,10 @@ proc insertPrompt*(t: var Terminal) =
     t.ed.appendOutput(t.cwd & " [" & t.branch & "]>")
   else:
     t.ed.appendOutput(t.cwd & ">")
+  # A prompt is not a program's output, and redrawing a live tail must never
+  # reach back over one. Saying it here rather than at each of the places that
+  # write a prompt is what keeps the two from drifting apart.
+  t.liveStart = t.ed.len
 
 # ---------------------------------------------------------------------------
 # Tab completion
@@ -709,7 +762,7 @@ proc runCommand*(t: var Terminal; cmd: var string): TermAction =
   t.hist[t.process].addCmd(cmd)
   t.ran.add cmd
   if t.processRunning:
-    requests.send(ThreadTask(cwd: t.cwd, cmd: cmd))
+    requests.send(ThreadTask(cwd: t.cwd, cmd: cmd, cols: t.cols, rows: t.rows))
     return
 
   var a = ""
@@ -813,7 +866,9 @@ proc runCommand*(t: var Terminal; cmd: var string): TermAction =
         a.startsWith"https://"):
       openDefaultBrowser(a)
     else:
-      requests.send(ThreadTask(cwd: t.cwd, cmd: cmd))
+      t.endOutput()
+      requests.send(ThreadTask(cwd: t.cwd, cmd: cmd,
+                               cols: t.cols, rows: t.rows))
       t.processRunning = true
       swap(t.process, cmd)
       if t.process notin t.hist:
@@ -827,27 +882,37 @@ proc enterPressed(t: var Terminal): TermAction =
 # Update (poll background thread)
 # ---------------------------------------------------------------------------
 
-proc showOutput(t: var Terminal; raw: string) =
-  ## What a program printed, with the escape sequences taken out and the color
-  ## they asked for put on the text instead.
-  ##
-  ## A chunk that asked for nothing is left to the highlighter, which is what
-  ## keeps the `+` and `-` lines of a plain `git diff` green and red. A chunk
-  ## that did ask overrules it: the program knows what its output means and
-  ## the highlighter is only ever guessing from the shape of a line.
-  var text = ""
-  var runs: seq[AnsiRun] = @[]
-  let colored = t.ansi.parseAnsi(raw, t.ed.tabSize, text, runs)
-  if text.len == 0: return
+proc renderRow(t: var Terminal; r: TermRow; newline: bool) =
   let start = t.ed.len
-  t.ed.appendOutput(text, highlight = not colored)
-  if colored:
+  let txt = if newline: r.text & "\L" else: r.text
+  t.ed.appendOutput(txt, highlight = not r.colored)
+  if r.colored:
     var pos = start
-    for r in runs:
-      if r.tc != TokenClass.None:
-        t.ed.setStyleRange(pos, pos + r.len - 1, r.tc)
-      pos += r.len
+    for run in r.runs:
+      if run.tc != TokenClass.None:
+        t.ed.setStyleRange(pos, pos + run.len - 1, run.tc)
+      pos += run.len
     t.ed.markProgramColored(pos)
+
+proc showOutput(t: var Terminal; raw: string) =
+  ## What a program printed, as rows.
+  ##
+  ## A row it can still draw on again is not written into the buffer once and
+  ## left there: a progress meter rewrites its line every time it moves, so
+  ## the whole live tail comes back off and goes on again. Rows the program
+  ## has printed past are final and are never touched a second time -- which
+  ## is what keeps the cost of this to the handful of rows a meter uses,
+  ## whatever the length of the output above them.
+  ##
+  ## A row the program colored keeps the program's colors. A row it did not is
+  ## still the highlighter's to guess at, which is what keeps a `+` line green
+  ## in the output of something that never heard of color.
+  let final = t.screen.feed(raw, t.ed.tabSize)
+  t.ed.truncateOutput(t.liveStart)
+  for r in final: t.renderRow(r, newline = true)
+  t.liveStart = t.ed.len
+  for i, r in t.screen.rows:
+    t.renderRow(r, newline = i < t.screen.rows.high)
 
 proc update*(t: var Terminal): bool =
   ## Takes whatever the thread running a program has said since the last look.
@@ -868,9 +933,9 @@ proc update*(t: var Terminal): bool =
       if resp.finished:
         t.processRunning = false
         t.process.setLen 0
-        # A program that died in the middle of a color must not leave the next
-        # one printing in it.
-        t.ansi = initAnsiState()
+        # A program that died in the middle of a color, or halfway through
+        # drawing a row, must not leave the next one carrying on from there.
+        t.endOutput()
         t.ed.appendOutput "\L"
         t.insertPrompt()
       result = true
@@ -891,7 +956,8 @@ proc createTerminal*(font: Font; theme = defaultTheme()): Terminal =
     prefix: "",
     aliases: @[],
     process: "",
-    ansi: initAnsiState(),
+    screen: initTermScreen(),
+    cols: 80, rows: 24,
     cwd: os.getCurrentDir())
   result.ed.lang = langConsole
   result.hist[""] = CmdHistory(cmds: @[], suggested: -1)
@@ -905,6 +971,11 @@ proc draw*(t: var Terminal; e: Event; area: Rect; focused: bool): TermAction =
   ## Per-frame entry point. When focused, processes input and shows cursor.
   ## When not focused, just paints. Always polls for process output.
   result = TermAction(kind: noAction)
+  # What a program starting here will be told it has to draw on. Read every
+  # frame because the panel is resized by dragging, and nothing else says so.
+  let ch = t.ed.charSize
+  t.cols = max(20, area.w div ch.w)
+  t.rows = max(4, area.h div ch.h)
   discard t.update()
 
   if focused:

--- a/src/widgets/terminal.nim
+++ b/src/widgets/terminal.nim
@@ -13,10 +13,11 @@
 ## The terminal runs commands in a background thread and streams
 ## their output into the editor buffer.
 
-import std/[os, osproc, streams, strutils, tables, times, browsers]
+import std/[os, osproc, streams, strtabs, strutils, tables, times, browsers]
 when defined(windows): import std/winlean
 else: import std/posix
 import synedit
+import ansi
 import filesearch
 import ../uirelays/[coords, screen, input]
 
@@ -222,6 +223,36 @@ else:
     result = posix.read(p.outputHandle, addr buf[0], buf.len)
     if result < 0: result = 0
 
+var forcedEnv {.threadvar.}: StringTableRef
+  ## Built once, on the thread that spawns -- a `threadvar` because that is
+  ## the thread that owns it, and a global would make every proc that touches
+  ## it un-GC-safe.
+
+proc colorEnv(): StringTableRef =
+  ## The environment a command is run in, with color asked for. Everything
+  ## here comes out of a pipe rather than a terminal, and a program that looks
+  ## before it colors -- which is all of them -- finds a pipe and turns color
+  ## off. These are the ways to say "do it anyway" that between them cover
+  ## what actually gets read in this panel; a variable the user already set is
+  ## left alone, since they have said something more specific than this has.
+  if forcedEnv == nil:
+    # Windows compares environment variable names without regard to case, so
+    # a table that does not would answer "no" to `PATH` and add a second one.
+    forcedEnv = newStringTable(
+      when defined(windows): modeCaseInsensitive else: modeCaseSensitive)
+    for k, v in envPairs(): forcedEnv[k] = v
+    template unless(key, value: string) =
+      if not forcedEnv.hasKey(key): forcedEnv[key] = value
+    unless("CLICOLOR_FORCE", "1")
+    unless("FORCE_COLOR", "1")
+    # Git has no environment variable for it, but it does take configuration
+    # from one, and `color.ui=always` is what `--color` sets.
+    if not forcedEnv.hasKey("GIT_CONFIG_COUNT"):
+      forcedEnv["GIT_CONFIG_COUNT"] = "1"
+      forcedEnv["GIT_CONFIG_KEY_0"] = "color.ui"
+      forcedEnv["GIT_CONFIG_VALUE_0"] = "always"
+  result = forcedEnv
+
 proc execThreadProc() {.thread.} =
   var p: Process
   var started = false
@@ -251,7 +282,7 @@ proc execThreadProc() {.thread.} =
           if not started:
             let (bin, args) = cmdToArgs(task.cmd)
             try:
-              p = startProcess(bin, task.cwd, args,
+              p = startProcess(bin, task.cwd, args, env = colorEnv(),
                         options = {poStdErrToStdOut, poUsePath, poInteractive,
                                    poDaemon})
               started = true
@@ -372,6 +403,10 @@ type
                         ## only a command here. In a terminal the same word is
                         ## a program's name, which is where it belongs -- see
                         ## `defaults` below.
+    ansi: AnsiState     ## the color a running program last asked for, and any
+                        ## escape sequence the end of a chunk cut in half --
+                        ## neither of which can be worked out from the next
+                        ## chunk on its own. See `showOutput`.
     branch: string      ## cached result of `gitBranch`; see `insertPrompt`
     branchDir: string   ## the directory `branch` was read for. Anything else,
                         ## "" included, means the cache says nothing about the
@@ -776,6 +811,28 @@ proc enterPressed(t: var Terminal): TermAction =
 # Update (poll background thread)
 # ---------------------------------------------------------------------------
 
+proc showOutput(t: var Terminal; raw: string) =
+  ## What a program printed, with the escape sequences taken out and the color
+  ## they asked for put on the text instead.
+  ##
+  ## A chunk that asked for nothing is left to the highlighter, which is what
+  ## keeps the `+` and `-` lines of a plain `git diff` green and red. A chunk
+  ## that did ask overrules it: the program knows what its output means and
+  ## the highlighter is only ever guessing from the shape of a line.
+  var text = ""
+  var runs: seq[AnsiRun] = @[]
+  let colored = t.ansi.parseAnsi(raw, t.ed.tabSize, text, runs)
+  if text.len == 0: return
+  let start = t.ed.len
+  t.ed.appendOutput(text, highlight = not colored)
+  if colored:
+    var pos = start
+    for r in runs:
+      if r.tc != TokenClass.None:
+        t.ed.setStyleRange(pos, pos + r.len - 1, r.tc)
+      pos += r.len
+    t.ed.markProgramColored(pos)
+
 proc update*(t: var Terminal): bool =
   ## Takes whatever the thread running a program has said since the last look.
   ## True when it said anything -- output to show, or the end of the program
@@ -791,10 +848,13 @@ proc update*(t: var Terminal): bool =
     if responses.peek > 0:
       let resp = responses.recv()
       if resp.text.len > 0:
-        t.ed.appendOutput(resp.text)
+        t.showOutput(resp.text)
       if resp.finished:
         t.processRunning = false
         t.process.setLen 0
+        # A program that died in the middle of a color must not leave the next
+        # one printing in it.
+        t.ansi = initAnsiState()
         t.ed.appendOutput "\L"
         t.insertPrompt()
       result = true
@@ -815,6 +875,7 @@ proc createTerminal*(font: Font; theme = defaultTheme()): Terminal =
     prefix: "",
     aliases: @[],
     process: "",
+    ansi: initAnsiState(),
     cwd: os.getCurrentDir())
   result.ed.lang = langConsole
   result.hist[""] = CmdHistory(cmds: @[], suggested: -1)

--- a/src/widgets/terminal.nim
+++ b/src/widgets/terminal.nim
@@ -463,6 +463,9 @@ type
     liveStart: int      ## the buffer offset those rows begin at. Everything
                         ## before it is final; everything after is redrawn
                         ## whenever the program moves.
+    outputStart: int    ## where the running program's output began, so that
+                        ## the view can be left at the top of it when the
+                        ## program is done. -1 when nothing is running.
     cols, rows: int     ## the panel's size in characters, as last drawn, and
                         ## what a program starting here is told it has.
     branch: string      ## cached result of `gitBranch`; see `insertPrompt`
@@ -502,10 +505,14 @@ proc endOutput(t: var Terminal) =
   t.liveStart = t.ed.len
 
 proc caretToEnd(t: var Terminal) =
-  ## Put the caret back where typing goes. What a program printed is text like
+  ## Put the caret back where typing goes, and the view back where the caret
+  ## is -- it may have been left at the top of a long piece of output on
+  ## purpose, and somebody who has started typing is done reading it.
+  ## What a program printed is text like
   ## any other here -- the caret walks into it and a selection can be taken out
   ## of it -- but a key that *edits* belongs to the line being typed, so
   ## everything that edits comes through here first.
+  t.ed.revealCaret()
   if t.ed.cursor.int > t.ed.readOnly: return
   t.ed.deselect()
   t.ed.gotoPos(t.ed.len)
@@ -867,6 +874,7 @@ proc runCommand*(t: var Terminal; cmd: var string): TermAction =
       openDefaultBrowser(a)
     else:
       t.endOutput()
+      t.outputStart = t.ed.len
       requests.send(ThreadTask(cwd: t.cwd, cmd: cmd,
                                cols: t.cols, rows: t.rows))
       t.processRunning = true
@@ -969,6 +977,11 @@ proc update*(t: var Terminal): bool =
         t.endOutput()
         t.ed.appendOutput "\L"
         t.insertPrompt()
+        # Last, because writing the prompt moves the caret and the view goes
+        # with it.
+        if t.outputStart >= 0:
+          t.ed.scrollToOutput(t.outputStart)
+          t.outputStart = -1
       result = true
 
 proc sendBreak*(t: var Terminal) =
@@ -988,6 +1001,7 @@ proc createTerminal*(font: Font; theme = defaultTheme()): Terminal =
     aliases: @[],
     process: "",
     screen: initTermScreen(),
+    outputStart: -1,
     cols: 80, rows: 24,
     cwd: os.getCurrentDir())
   result.ed.lang = langConsole
@@ -1026,6 +1040,7 @@ proc draw*(t: var Terminal; e: Event; area: Rect; focused: bool): TermAction =
         # in the output, Up is what it is in the editor and walks it further
         # up. Shift and Ctrl always mean select and scroll.
         if not ctrl and not shift and t.ed.cursor.int > t.ed.readOnly:
+          t.ed.revealCaret()
           let sug = t.hist[t.process].suggest(up = true)
           if sug.len > 0:
             t.emptyCmd()
@@ -1034,6 +1049,7 @@ proc draw*(t: var Terminal; e: Event; area: Rect; focused: bool): TermAction =
           return
       of KeyDown:
         if not ctrl and not shift and t.ed.cursor.int > t.ed.readOnly:
+          t.ed.revealCaret()
           let sug = t.hist[t.process].suggest(up = false)
           if sug.len > 0:
             t.emptyCmd()
@@ -1041,6 +1057,7 @@ proc draw*(t: var Terminal; e: Event; area: Rect; focused: bool): TermAction =
           t.ed.render(area, showCursor = true)
           return
       of KeyTab:
+        t.ed.revealCaret()
         t.tabPressed()
         t.ed.render(area, showCursor = true)
         return

--- a/src/widgets/theme.nim
+++ b/src/widgets/theme.nim
@@ -14,7 +14,16 @@ type
     TagStart, TagStandalone, TagEnd, Key, Value, RawData, Assembler,
     Preprocessor, Directive, Command, Rule, Link, Label,
     Reference, Text, Other, Green, Yellow, Red,
-    MarkdownFence
+    MarkdownFence,
+    # The sixteen a terminal has. `Green`, `Yellow` and `Red` above are three
+    # of them: the console highlighter already guesses those from the shape of
+    # a line, and a program that asks for them by name must not come out in a
+    # different shade than a `+` line does. The rest are new, and a theme is
+    # expected to answer for all sixteen -- ANSI black is not black here, it
+    # is whatever this theme's dimmest legible foreground is.
+    Black, Blue, Magenta, Cyan, White,
+    BrightBlack, BrightRed, BrightGreen, BrightYellow,
+    BrightBlue, BrightMagenta, BrightCyan, BrightWhite
 
   Theme* = object
     fg*: array[TokenClass, Color]   ## per-token foreground colors
@@ -135,6 +144,22 @@ proc catppuccinMocha*(): Theme =
   result.fg[TokenClass.Red] = color(243, 139, 168)
   result.fg[TokenClass.MarkdownFence] = color(128, 128, 128)
   result.fg[TokenClass.Link] = color(137, 180, 250)       # blue
+  # The sixteen. Catppuccin names its own ANSI set; the two darkest of them
+  # are lifted to `overlay1`/`overlay2` because a foreground has to be legible
+  # against `base`, and surface grey is not.
+  result.fg[TokenClass.Black] = color(127, 132, 156)       # overlay1
+  result.fg[TokenClass.Blue] = color(137, 180, 250)
+  result.fg[TokenClass.Magenta] = color(245, 194, 231)     # pink
+  result.fg[TokenClass.Cyan] = color(148, 226, 213)        # teal
+  result.fg[TokenClass.White] = color(186, 194, 222)       # subtext1
+  result.fg[TokenClass.BrightBlack] = color(147, 153, 178) # overlay2
+  result.fg[TokenClass.BrightRed] = color(235, 160, 172)   # maroon
+  result.fg[TokenClass.BrightGreen] = color(183, 232, 179)
+  result.fg[TokenClass.BrightYellow] = color(250, 234, 196)
+  result.fg[TokenClass.BrightBlue] = color(160, 195, 251)
+  result.fg[TokenClass.BrightMagenta] = color(248, 210, 238)
+  result.fg[TokenClass.BrightCyan] = color(172, 233, 223)
+  result.fg[TokenClass.BrightWhite] = color(230, 238, 255) # above the text
   result.bg = color(30, 30, 46)
   result.panelBg = color(24, 24, 37)             # crust, a step below the base
   result.selBg = color(88, 91, 112)
@@ -208,6 +233,22 @@ proc goldenDusk*(): Theme =
   result.fg[TokenClass.Green] = color(0x4F, 0xBF, 0x9F)
   result.fg[TokenClass.Yellow] = gold
   result.fg[TokenClass.Red] = color(0xE4, 0x63, 0x4A)
+  # And the sixteen a terminal has, in this theme's own gold and turquoise
+  # rather than in the primaries -- a program that asks for blue gets the cool
+  # accent here, because that is what blue is on this background.
+  result.fg[TokenClass.Black] = dim
+  result.fg[TokenClass.Blue] = turquoise
+  result.fg[TokenClass.Magenta] = color(0xD8, 0x8A, 0xA8)  # dusty rose
+  result.fg[TokenClass.Cyan] = brightTurq
+  result.fg[TokenClass.White] = text
+  result.fg[TokenClass.BrightBlack] = muted
+  result.fg[TokenClass.BrightRed] = color(0xF2, 0x86, 0x70)
+  result.fg[TokenClass.BrightGreen] = color(0x6F, 0xD9, 0xBB)
+  result.fg[TokenClass.BrightYellow] = color(0xF2, 0xCE, 0x7A)
+  result.fg[TokenClass.BrightBlue] = brightTurq
+  result.fg[TokenClass.BrightMagenta] = color(0xE8, 0xA6, 0xC0)
+  result.fg[TokenClass.BrightCyan] = color(0x7A, 0xE0, 0xD6)
+  result.fg[TokenClass.BrightWhite] = color(0xFF, 0xF8, 0xEA)
 
   result.bg = color(0x15, 0x17, 0x1B)
   result.panelBg = color(0x11, 0x13, 0x16)       # a step below the editor

--- a/tests/ansitest.nim
+++ b/tests/ansitest.nim
@@ -330,4 +330,54 @@ block:
   let text = ed.fullText
   equals("and what was dropped is gone", text, "green\Lplain\L")
 
+echo "landing at the top of what a command printed:"
+
+block:
+  # The panel is its own pager -- it scrolls, searches and keeps everything --
+  # but a pager also decides where you *start*, and following the output down
+  # leaves the reader at the oldest commit in the repository.
+  var ed = console()
+  var back = ""
+  for i in 1..50: back.add "old " & $i & "\L"
+  ed.appendOutput(back)
+  ed.appendOutput("$ git log\L")
+  ed.render(Area, showCursor = true)
+  let start = ed.len                 # where the command's own output begins
+  var printed = ""
+  for i in 1..100: printed.add "commit " & $i & "\L"
+  ed.appendOutput(printed)
+  ed.appendOutput("$ ")
+  ed.render(Area, showCursor = true)
+  check("by default the view has followed the output down",
+        ed.firstLine > 100, $ed.firstLine)
+  ed.scrollToOutput(start)
+  ed.render(Area, showCursor = true)
+  check("and a pager lands on the first line of it",
+        ed.firstLine == 51, $ed.firstLine)
+  # The caret is still down at the prompt, off the bottom of the view: moving
+  # it is what brings the view back, so the first key typed returns there.
+  check("with the caret still at the prompt", ed.cursor == ed.len, $ed.cursor)
+  # Typing does not chase the caret by itself, so the panel says so on the
+  # reader's behalf -- `Terminal.caretToEnd` does this for every key that
+  # edits the command line.
+  ed.revealCaret()
+  ed.insertText("x")
+  ed.render(Area, showCursor = true)
+  check("and the way back down is one keystroke", ed.firstLine > 100,
+        $ed.firstLine)
+
+block:
+  var ed = console()
+  ed.appendOutput("$ cd src\L")
+  ed.render(Area, showCursor = true)
+  let start = ed.len
+  ed.appendOutput("two\Llines\L")
+  ed.appendOutput("$ ")
+  ed.render(Area, showCursor = true)
+  let before = ed.firstLine
+  ed.scrollToOutput(start)
+  ed.render(Area, showCursor = true)
+  check("output that already fits is left exactly where it was",
+        ed.firstLine == before, $ed.firstLine & " was " & $before)
+
 quit(if failures > 0: 1 else: 0)

--- a/tests/ansitest.nim
+++ b/tests/ansitest.nim
@@ -1,0 +1,274 @@
+## What a program printed, once the escape sequences have been taken out of
+## it: the text a buffer should hold, the colors the program asked for, and --
+## just as much the point -- that everything it asked for which this panel has
+## no answer to disappears instead of coming out as `^[[?25h` in the middle of
+## a line. Needs no window for the parser half; the half that puts the colors
+## into a SynEdit runs through the same stub relays as `styletest`.
+import std/strutils
+import uirelays/[screen, coords, input]
+import widgets/[ansi, synedit, theme]
+
+fontRelays = FontRelays(
+  openFont: proc (path: string; size: int; style: FontStyles;
+                  metrics: var FontMetrics): Font =
+    metrics = FontMetrics(ascent: 12, descent: 4, lineHeight: 16)
+    Font(1),
+  closeFont: proc (f: Font) = discard,
+  getFontMetrics: proc (f: Font): FontMetrics =
+    FontMetrics(ascent: 12, descent: 4, lineHeight: 16),
+  measureText: proc (f: Font; text: string): TextExtent =
+    TextExtent(w: text.len * 8, h: 16),
+  drawText: proc (f: Font; x, y: int; text: string;
+                  fg, bg: Color): TextExtent =
+    TextExtent(w: text.len * 8, h: 16))
+
+drawRelays = DrawRelays(
+  fillRect: proc (r: Rect; color: Color) = discard,
+  drawLine: proc (x1, y1, x2, y2: int; color: Color) = discard,
+  drawPoint: proc (x, y: int; color: Color) = discard,
+  loadImage: proc (path: string): Image = Image(0),
+  freeImage: proc (img: Image) = discard,
+  drawImage: proc (img: Image; src, dst: Rect) = discard)
+
+var m: FontMetrics
+let font = openFont("", 16, m)
+
+var failures = 0
+
+proc check(name: string; cond: bool; detail = "") =
+  if cond:
+    echo "  PASS  ", name
+  else:
+    inc failures
+    echo "  FAIL  ", name, (if detail.len > 0: "  -- " & detail else: "")
+
+proc equals(name: string; got, want: string) =
+  check(name, got == want, "got '" & got & "' want '" & want & "'")
+
+# ---------------------------------------------------------------------------
+# The parser
+# ---------------------------------------------------------------------------
+
+proc textOf(input: string; tabSize = 2): string =
+  var st = initAnsiState()
+  var runs: seq[AnsiRun] = @[]
+  discard st.parseAnsi(input, tabSize, result, runs)
+
+proc colorsOf(input: string): string =
+  ## The runs as `text:Class`, so a test can name both at once.
+  var st = initAnsiState()
+  var text = ""
+  var runs: seq[AnsiRun] = @[]
+  discard st.parseAnsi(input, 2, text, runs)
+  var pos = 0
+  var parts: seq[string] = @[]
+  for r in runs:
+    parts.add text[pos ..< pos + r.len] & ":" & $r.tc
+    pos += r.len
+  result = parts.join(" ")
+
+proc sawColor(input: string): bool =
+  var st = initAnsiState()
+  var text = ""
+  var runs: seq[AnsiRun] = @[]
+  result = st.parseAnsi(input, 2, text, runs)
+
+echo "text comes out clean:"
+
+block:
+  equals("plain text is left alone", textOf("hello"), "hello")
+  equals("a color is taken out", textOf("\e[32mgreen\e[m"), "green")
+  equals("and so is a cursor move", textOf("a\e[24;1Hb"), "ab")
+  equals("erase, hide, show", textOf("a\e[Kb\e[?25lc\e[?25hd"), "abcd")
+  equals("a two-byte escape", textOf("a\e7b\eMc"), "abc")
+  equals("an OSC ending in BEL", textOf("a\e]0;a title\ab"), "ab")
+  equals("an OSC ending in ST", textOf("a\e]8;;http://x\e\\b"), "ab")
+  equals("a lone ESC at the end is held back, not printed",
+         textOf("ab\e"), "ab")
+  # `rawInsert` expands tabs and drops carriage returns, so the parser has to
+  # do it too -- a run counts bytes the buffer will actually hold.
+  equals("tabs are expanded the way the buffer expands them",
+         textOf("a\tb", tabSize = 4), "a    b")
+  equals("carriage returns are dropped", textOf("a\c\Lb"), "a\Lb")
+
+echo "colors are the ones asked for:"
+
+block:
+  equals("the eight", colorsOf("\e[31mr\e[32mg\e[33my\e[34mb\e[m."),
+         "r:Red g:Green y:Yellow b:Blue .:None")
+  equals("reset by 0 as well as by nothing",
+         colorsOf("\e[36mc\e[0m."), "c:Cyan .:None")
+  equals("39 is the default too", colorsOf("\e[35mm\e[39m."),
+         "m:Magenta .:None")
+  # `ls --color=always` says `01;34` and every terminal since the VT100 has
+  # drawn that as bright blue.
+  equals("bold makes a color its bright twin",
+         colorsOf("\e[01;34mdir\e[0m"), "dir:BrightBlue")
+  equals("and 22 takes it off again",
+         colorsOf("\e[1;31ma\e[22mb"), "a:BrightRed b:Red")
+  equals("the bright eight say so themselves",
+         colorsOf("\e[90ma\e[97mb"), "a:BrightBlack b:BrightWhite")
+  # `git log` marks its `commit` and `diff --git` lines with nothing but this.
+  equals("bold alone is the default color, emphasised",
+         colorsOf("\e[1mbold\e[m"), "bold:BrightWhite")
+
+block:
+  # Claude Code's own output, which is where the 24-bit ones come from.
+  equals("24-bit gray lands on the nearest of the sixteen",
+         colorsOf("\e[38;2;153;153;153ma\e[m"), "a:BrightBlack")
+  equals("24-bit amber lands on yellow",
+         colorsOf("\e[38;2;255;193;7ma\e[m"), "a:Yellow")
+  equals("256-color red", colorsOf("\e[38;5;196ma\e[m"), "a:BrightRed")
+  equals("256-color index below 16 is that color",
+         colorsOf("\e[38;5;2ma\e[m"), "a:Green")
+  equals("a background is swallowed, and takes its arguments with it",
+         colorsOf("\e[48;2;0;0;0mx\e[49my"), "xy:None")
+  equals("so is one of 256", colorsOf("\e[48;5;17mx\e[m"), "x:None")
+
+block:
+  equals("a private sequence is not a color", colorsOf("\e[>4mx"), "x:None")
+  equals("nor is a keyboard query", colorsOf("\e[<ux"), "x:None")
+  check("SGR is what sets the flag", sawColor("\e[32ma"))
+  check("a cursor move does not", not sawColor("a\e[2Jb\e[Hc"))
+  check("and neither does plain text", not sawColor("hello"))
+
+echo "a chunk boundary anywhere:"
+
+block:
+  # A `read` returns what has arrived, which may be four bytes into a color.
+  var st = initAnsiState()
+  var text = ""
+  var runs: seq[AnsiRun] = @[]
+  discard st.parseAnsi("red \e[3", 2, text, runs)
+  equals("the half-written escape is held back", text, "red ")
+  discard st.parseAnsi("2mgreen", 2, text, runs)
+  equals("and finished by the chunk after it", text, "red green")
+  var pos = 0
+  var last = TokenClass.None
+  for r in runs:
+    if pos + r.len == text.len: last = r.tc
+    pos += r.len
+  check("the color it carried is in force", last == TokenClass.Green, $last)
+
+block:
+  var st = initAnsiState()
+  var text = ""
+  var runs: seq[AnsiRun] = @[]
+  discard st.parseAnsi("a\e]0;half a ti", 2, text, runs)
+  discard st.parseAnsi("tle\ab", 2, text, runs)
+  equals("an OSC split down the middle", text, "ab")
+
+block:
+  var st = initAnsiState()
+  var text = ""
+  var runs: seq[AnsiRun] = @[]
+  discard st.parseAnsi("\e[33m", 2, text, runs)
+  discard st.parseAnsi("still yellow", 2, text, runs)
+  equals("a color outlives the chunk that asked for it",
+         colorsOf("\e[33mstill yellow"), "still yellow:Yellow")
+  check("across chunks as well", runs.len == 1 and runs[0].tc == TokenClass.Yellow,
+        $runs.len)
+
+block:
+  # An `ESC` in the middle of a binary file starts a sequence that never ends,
+  # and holding on to the rest of the file waiting for it is how a terminal
+  # that met a `.tar` stops showing anything at all.
+  var st = initAnsiState()
+  var text = ""
+  var runs: seq[AnsiRun] = @[]
+  discard st.parseAnsi("\e]" & repeat('x', 4000), 2, text, runs)
+  discard st.parseAnsi("after", 2, text, runs)
+  equals("a runaway escape is given up on", text, "after")
+
+echo "what git actually prints:"
+
+block:
+  # Copied off `git -c color.ui=always log -p`.
+  const diff = "\e[33mcommit abc123\e[m\L\e[1mdiff --git\e[m\L" &
+               "\e[36m@@ -1 +1 @@\e[m\L\e[32m+added\e[m\L\e[31m-gone\e[m\L"
+  equals("the diff reads as a diff", textOf(diff),
+         "commit abc123\Ldiff --git\L@@ -1 +1 @@\L+added\L-gone\L")
+  equals("in the colors it asked for", colorsOf(diff),
+         "commit abc123:Yellow \L:None diff --git:BrightWhite \L:None " &
+         "@@ -1 +1 @@:Cyan \L:None +added:Green \L:None -gone:Red \L:None")
+
+# ---------------------------------------------------------------------------
+# Into a buffer
+# ---------------------------------------------------------------------------
+
+echo "the colors survive in the buffer:"
+
+const Area = rect(0, 0, 400, 300)
+
+proc console(): SynEdit =
+  result = createSynEdit(font, defaultTheme())
+  result.lang = langConsole
+
+proc show(ed: var SynEdit; raw: string) =
+  ## What `Terminal.showOutput` does, in the two lines of it that matter here.
+  var st = initAnsiState()
+  var text = ""
+  var runs: seq[AnsiRun] = @[]
+  let colored = st.parseAnsi(raw, ed.tabSize, text, runs)
+  let start = ed.len
+  ed.appendOutput(text, highlight = not colored)
+  if colored:
+    var pos = start
+    for r in runs:
+      if r.tc != TokenClass.None: ed.setStyleRange(pos, pos + r.len - 1, r.tc)
+      pos += r.len
+    ed.markProgramColored(pos)
+
+proc classAt(ed: SynEdit; needle: string; text: string): TokenClass =
+  let i = text.find(needle)
+  doAssert i >= 0, needle
+  ed.tokenClassAt(i)
+
+block:
+  # A line that starts with `-` is what the highlighter paints red by guessing.
+  # Here the program says it is green, and the program wins.
+  var ed = console()
+  ed.show("\e[32m-not really a deletion\e[m\L")
+  check("the program's color is the one that lands",
+        ed.tokenClassAt(0) == TokenClass.Green, $ed.tokenClassAt(0))
+
+block:
+  var ed = console()
+  ed.show("\e[36mcyan\e[m\L")
+  # An edit sends the incremental highlighter back to the start of the buffer,
+  # and a render is where it runs. Without the watermark it would repaint the
+  # program's output with whatever the shape of the lines suggests.
+  ed.insertText("typing")
+  ed.render(Area, showCursor = true)
+  ed.render(Area, showCursor = true)
+  check("and it survives an edit further down",
+        ed.tokenClassAt(0) == TokenClass.Cyan, $ed.tokenClassAt(0))
+
+block:
+  # Output with no escapes in it is still the highlighter's to color, or a
+  # plain `git diff` would come out grey.
+  var ed = console()
+  ed.show("+added\L-gone\L")
+  ed.render(Area, showCursor = true)
+  let text = ed.fullText
+  check("a `+` line is still guessed green",
+        ed.classAt("+added", text) == TokenClass.Green,
+        $ed.classAt("+added", text))
+  check("and a `-` line red", ed.classAt("-gone", text) == TokenClass.Red,
+        $ed.classAt("-gone", text))
+
+block:
+  # The two kinds of chunk, one after the other.
+  var ed = console()
+  ed.show("\e[33myellow\e[m\L")
+  ed.show("+added\L")
+  ed.render(Area, showCursor = true)
+  let text = ed.fullText
+  check("the colored chunk keeps the program's color",
+        ed.classAt("yellow", text) == TokenClass.Yellow,
+        $ed.classAt("yellow", text))
+  check("and the plain one after it is still guessed",
+        ed.classAt("+added", text) == TokenClass.Green,
+        $ed.classAt("+added", text))
+
+quit(if failures > 0: 1 else: 0)

--- a/tests/ansitest.nim
+++ b/tests/ansitest.nim
@@ -46,50 +46,52 @@ proc equals(name: string; got, want: string) =
   check(name, got == want, "got '" & got & "' want '" & want & "'")
 
 # ---------------------------------------------------------------------------
-# The parser
+# The parser and the rows it draws on
 # ---------------------------------------------------------------------------
 
+proc rowsOf(input: string; tabSize = 2): seq[TermRow] =
+  ## Everything a chunk produced: the rows it finished with and the ones still
+  ## open to being drawn on.
+  var sc = initTermScreen()
+  result = sc.feed(input, tabSize)
+  for r in sc.rows: result.add r
+
 proc textOf(input: string; tabSize = 2): string =
-  var st = initAnsiState()
-  var runs: seq[AnsiRun] = @[]
-  discard st.parseAnsi(input, tabSize, result, runs)
+  var parts: seq[string] = @[]
+  for r in rowsOf(input, tabSize): parts.add r.text
+  result = parts.join("\L")
 
 proc colorsOf(input: string): string =
-  ## The runs as `text:Class`, so a test can name both at once.
-  var st = initAnsiState()
-  var text = ""
-  var runs: seq[AnsiRun] = @[]
-  discard st.parseAnsi(input, 2, text, runs)
-  var pos = 0
-  var parts: seq[string] = @[]
-  for r in runs:
-    parts.add text[pos ..< pos + r.len] & ":" & $r.tc
-    pos += r.len
-  result = parts.join(" ")
-
-proc sawColor(input: string): bool =
-  var st = initAnsiState()
-  var text = ""
-  var runs: seq[AnsiRun] = @[]
-  result = st.parseAnsi(input, 2, text, runs)
+  ## Every row as `text:Class` runs, rows separated by ` / `.
+  var lines: seq[string] = @[]
+  for r in rowsOf(input):
+    let text = r.text
+    var pos = 0
+    var parts: seq[string] = @[]
+    for run in r.runs:
+      parts.add text[pos ..< pos + run.len] & ":" & $run.tc
+      pos += run.len
+    lines.add parts.join(" ")
+  result = lines.join(" / ")
 
 echo "text comes out clean:"
 
 block:
   equals("plain text is left alone", textOf("hello"), "hello")
   equals("a color is taken out", textOf("\e[32mgreen\e[m"), "green")
-  equals("and so is a cursor move", textOf("a\e[24;1Hb"), "ab")
-  equals("erase, hide, show", textOf("a\e[Kb\e[?25lc\e[?25hd"), "abcd")
+  equals("a cursor move nobody answers here is swallowed",
+         textOf("a\e[24;1Hb"), "ab")
+  equals("hide and show", textOf("a\e[?25lb\e[?25hc"), "abc")
   equals("a two-byte escape", textOf("a\e7b\eMc"), "abc")
   equals("an OSC ending in BEL", textOf("a\e]0;a title\ab"), "ab")
   equals("an OSC ending in ST", textOf("a\e]8;;http://x\e\\b"), "ab")
   equals("a lone ESC at the end is held back, not printed",
          textOf("ab\e"), "ab")
-  # `rawInsert` expands tabs and drops carriage returns, so the parser has to
-  # do it too -- a run counts bytes the buffer will actually hold.
-  equals("tabs are expanded the way the buffer expands them",
-         textOf("a\tb", tabSize = 4), "a    b")
-  equals("carriage returns are dropped", textOf("a\c\Lb"), "a\Lb")
+  equals("tabs become spaces", textOf("a\tb", tabSize = 4), "a    b")
+  equals("a newline is a new row", textOf("a\nb"), "a\Lb")
+  equals("and a pty's \\r\\n is the same thing said twice",
+         textOf("a\c\Lb"), "a\Lb")
+  equals("a rune of several bytes stays whole", textOf("a—b"), "a—b")
 
 echo "colors are the ones asked for:"
 
@@ -128,69 +130,98 @@ block:
 block:
   equals("a private sequence is not a color", colorsOf("\e[>4mx"), "x:None")
   equals("nor is a keyboard query", colorsOf("\e[<ux"), "x:None")
-  check("SGR is what sets the flag", sawColor("\e[32ma"))
-  check("a cursor move does not", not sawColor("a\e[2Jb\e[Hc"))
-  check("and neither does plain text", not sawColor("hello"))
+  check("a row that was colored says so", rowsOf("\e[32ma")[0].colored)
+  check("and one that was not does not", not rowsOf("plain")[0].colored)
+
+echo "what a progress meter does:"
+
+block:
+  # The whole point: a meter rewrites its line rather than adding one.
+  equals("a carriage return draws over the line again",
+         textOf("\r 10%\r 50%\r100%"), "100%")
+  equals("erase to the end of the line rubs out what was longer",
+         textOf("aaaaaaaaaa\r\e[Kshort"), "short")
+  equals("erase the whole line", textOf("hello\e[2Kbye"), "     bye")
+  equals("a backspace steps back over one column",
+         textOf("abcx\bd"), "abcd")
+  equals("an absolute column", textOf("..........\e[5Gx"), "....x.....")
+  equals("forward and back", textOf("abc\e[2Dx"), "axc")
+
+block:
+  # A meter that counts several things at once draws them on several rows and
+  # goes back up to the first.
+  # The row after them is where the cursor was left standing, and it is empty.
+  equals("two rows, drawn on again from the top",
+         textOf("one\ntwo\n\e[2Aone!\ntwo!"), "one!\Ltwo!\L")
+  # Up and down keep the column they are in -- only a carriage return or a
+  # newline goes back to the left, which is what makes `\r` the meter's tool.
+  equals("down is the other way, and stays in its column",
+         textOf("a\n\e[1Ax\e[1Bb"), "x\L b")
+
+block:
+  # Rows the meter has printed past are final: they are handed over, and the
+  # cursor can no longer reach them.
+  var sc = initTermScreen()
+  var final = sc.feed("keep\n", 2)
+  check("a row still within reach is not final yet", final.len == 0,
+        $final.len)
+  var lines = ""
+  for i in 1 .. LiveRows + 4: lines.add "row" & $i & "\n"
+  final = sc.feed(lines, 2)
+  check("but one pushed past the tail is", final.len == 6, $final.len)
+  equals("and it is the oldest that goes first", final[0].text, "keep")
+  check("the tail keeps its bound", sc.rows.len == LiveRows, $sc.rows.len)
 
 echo "a chunk boundary anywhere:"
 
 block:
-  # A `read` returns what has arrived, which may be four bytes into a color.
-  var st = initAnsiState()
-  var text = ""
-  var runs: seq[AnsiRun] = @[]
-  discard st.parseAnsi("red \e[3", 2, text, runs)
-  equals("the half-written escape is held back", text, "red ")
-  discard st.parseAnsi("2mgreen", 2, text, runs)
-  equals("and finished by the chunk after it", text, "red green")
-  var pos = 0
-  var last = TokenClass.None
-  for r in runs:
-    if pos + r.len == text.len: last = r.tc
-    pos += r.len
-  check("the color it carried is in force", last == TokenClass.Green, $last)
+  var sc = initTermScreen()
+  discard sc.feed("red \e[3", 2)
+  equals("the half-written escape is held back", sc.rows[0].text, "red ")
+  discard sc.feed("2mgreen", 2)
+  equals("and is finished by the chunk after it, in its color",
+         sc.rows[0].text, "red green")
+  check("which is the color it carried", sc.rows[0].colored)
 
 block:
-  var st = initAnsiState()
-  var text = ""
-  var runs: seq[AnsiRun] = @[]
-  discard st.parseAnsi("a\e]0;half a ti", 2, text, runs)
-  discard st.parseAnsi("tle\ab", 2, text, runs)
-  equals("an OSC split down the middle", text, "ab")
+  var sc = initTermScreen()
+  discard sc.feed("a\e]0;half a ti", 2)
+  discard sc.feed("tle\ab", 2)
+  equals("an OSC split down the middle", sc.rows[0].text, "ab")
 
 block:
-  var st = initAnsiState()
-  var text = ""
-  var runs: seq[AnsiRun] = @[]
-  discard st.parseAnsi("\e[33m", 2, text, runs)
-  discard st.parseAnsi("still yellow", 2, text, runs)
+  var sc = initTermScreen()
+  discard sc.feed("a\xE2\x80", 2)      # an em dash, cut after two bytes
+  discard sc.feed("\x94b", 2)
+  equals("a rune split down the middle", sc.rows[0].text, "a—b")
+
+block:
+  var sc = initTermScreen()
+  discard sc.feed("\e[33m", 2)
+  discard sc.feed("still yellow", 2)
   equals("a color outlives the chunk that asked for it",
-         colorsOf("\e[33mstill yellow"), "still yellow:Yellow")
-  check("across chunks as well", runs.len == 1 and runs[0].tc == TokenClass.Yellow,
-        $runs.len)
+         sc.rows[0].runs[0].tc.`$`, "Yellow")
 
 block:
   # An `ESC` in the middle of a binary file starts a sequence that never ends,
   # and holding on to the rest of the file waiting for it is how a terminal
   # that met a `.tar` stops showing anything at all.
-  var st = initAnsiState()
-  var text = ""
-  var runs: seq[AnsiRun] = @[]
-  discard st.parseAnsi("\e]" & repeat('x', 4000), 2, text, runs)
-  discard st.parseAnsi("after", 2, text, runs)
-  equals("a runaway escape is given up on", text, "after")
+  var sc = initTermScreen()
+  discard sc.feed("\e]" & repeat('x', 4000), 2)
+  discard sc.feed("after", 2)
+  equals("a runaway escape is given up on", sc.rows[0].text, "after")
 
 echo "what git actually prints:"
 
 block:
-  # Copied off `git -c color.ui=always log -p`.
-  const diff = "\e[33mcommit abc123\e[m\L\e[1mdiff --git\e[m\L" &
-               "\e[36m@@ -1 +1 @@\e[m\L\e[32m+added\e[m\L\e[31m-gone\e[m\L"
+  # Copied off a `git log -p` read through a pty, `\r\n` and all.
+  const diff = "\e[33mcommit abc123\e[m\c\L\e[1mdiff --git\e[m\c\L" &
+               "\e[36m@@ -1 +1 @@\e[m\c\L\e[32m+added\e[m\c\L\e[31m-gone\e[m\c\L"
   equals("the diff reads as a diff", textOf(diff),
          "commit abc123\Ldiff --git\L@@ -1 +1 @@\L+added\L-gone\L")
   equals("in the colors it asked for", colorsOf(diff),
-         "commit abc123:Yellow \L:None diff --git:BrightWhite \L:None " &
-         "@@ -1 +1 @@:Cyan \L:None +added:Green \L:None -gone:Red \L:None")
+         "commit abc123:Yellow / diff --git:BrightWhite / " &
+         "@@ -1 +1 @@:Cyan / +added:Green / -gone:Red / ")
 
 # ---------------------------------------------------------------------------
 # Into a buffer
@@ -204,20 +235,19 @@ proc console(): SynEdit =
   result = createSynEdit(font, defaultTheme())
   result.lang = langConsole
 
-proc show(ed: var SynEdit; raw: string) =
-  ## What `Terminal.showOutput` does, in the two lines of it that matter here.
-  var st = initAnsiState()
-  var text = ""
-  var runs: seq[AnsiRun] = @[]
-  let colored = st.parseAnsi(raw, ed.tabSize, text, runs)
+proc show(ed: var SynEdit; r: TermRow) =
+  ## What `Terminal.renderRow` does.
   let start = ed.len
-  ed.appendOutput(text, highlight = not colored)
-  if colored:
+  ed.appendOutput(r.text & "\L", highlight = not r.colored)
+  if r.colored:
     var pos = start
-    for r in runs:
-      if r.tc != TokenClass.None: ed.setStyleRange(pos, pos + r.len - 1, r.tc)
-      pos += r.len
+    for run in r.runs:
+      if run.tc != TokenClass.None: ed.setStyleRange(pos, pos + run.len - 1, run.tc)
+      pos += run.len
     ed.markProgramColored(pos)
+
+proc show(ed: var SynEdit; raw: string) =
+  for r in rowsOf(raw, ed.tabSize): ed.show(r)
 
 proc classAt(ed: SynEdit; needle: string; text: string): TokenClass =
   let i = text.find(needle)
@@ -228,13 +258,13 @@ block:
   # A line that starts with `-` is what the highlighter paints red by guessing.
   # Here the program says it is green, and the program wins.
   var ed = console()
-  ed.show("\e[32m-not really a deletion\e[m\L")
+  ed.show("\e[32m-not really a deletion\e[m")
   check("the program's color is the one that lands",
         ed.tokenClassAt(0) == TokenClass.Green, $ed.tokenClassAt(0))
 
 block:
   var ed = console()
-  ed.show("\e[36mcyan\e[m\L")
+  ed.show("\e[36mcyan\e[m")
   # An edit sends the incremental highlighter back to the start of the buffer,
   # and a render is where it runs. Without the watermark it would repaint the
   # program's output with whatever the shape of the lines suggests.
@@ -248,7 +278,7 @@ block:
   # Output with no escapes in it is still the highlighter's to color, or a
   # plain `git diff` would come out grey.
   var ed = console()
-  ed.show("+added\L-gone\L")
+  ed.show("+added\n-gone")
   ed.render(Area, showCursor = true)
   let text = ed.fullText
   check("a `+` line is still guessed green",
@@ -258,17 +288,46 @@ block:
         $ed.classAt("-gone", text))
 
 block:
-  # The two kinds of chunk, one after the other.
   var ed = console()
-  ed.show("\e[33myellow\e[m\L")
-  ed.show("+added\L")
+  ed.show("\e[33myellow\e[m")
+  ed.show("+added")
   ed.render(Area, showCursor = true)
   let text = ed.fullText
-  check("the colored chunk keeps the program's color",
+  check("the colored row keeps the program's color",
         ed.classAt("yellow", text) == TokenClass.Yellow,
         $ed.classAt("yellow", text))
   check("and the plain one after it is still guessed",
         ed.classAt("+added", text) == TokenClass.Green,
         $ed.classAt("+added", text))
+
+echo "taking a row back off:"
+
+block:
+  # What redrawing the live tail rests on.
+  var ed = console()
+  ed.appendOutput("keep\Lgone\Lalso gone")
+  let at = ed.fullText.find("gone")
+  ed.truncateOutput(at)
+  equals("everything from there is dropped", ed.fullText, "keep\L")
+  var newlines = 0
+  for i in 0 ..< ed.len:
+    if ed[i] == '\L': inc newlines
+  check("and the buffer holds one line break, not three", newlines == 1,
+        $newlines)
+  ed.appendOutput("new\L")
+  equals("and the buffer goes on from there", ed.fullText, "keep\Lnew\L")
+
+block:
+  var ed = console()
+  ed.show("\e[32mgreen\e[m")
+  let mark = ed.len
+  ed.show("\e[31mred\e[m")
+  ed.truncateOutput(mark)
+  ed.appendOutput("plain\L")
+  ed.render(Area, showCursor = true)
+  check("what was kept keeps its color",
+        ed.tokenClassAt(0) == TokenClass.Green, $ed.tokenClassAt(0))
+  let text = ed.fullText
+  equals("and what was dropped is gone", text, "green\Lplain\L")
 
 quit(if failures > 0: 1 else: 0)

--- a/tests/tablisttest.nim
+++ b/tests/tablisttest.nim
@@ -1,0 +1,144 @@
+## The tab list is a list whose active row is chosen somewhere else. The editor
+## decides which tab is current -- Ctrl+W, a file opened from the explorer, a
+## jump to a definition -- and the list has to go and show it, which nothing in
+## the list itself ever asked for. `centerLine` is that move, and this watches
+## the two things that make it stick: that it does not fall off either end of
+## the list, and that drawing the widget afterwards leaves it where it was,
+## focused or not.
+import uirelays/[screen, coords, input]
+import widgets/[synedit, theme]
+
+fontRelays = FontRelays(
+  openFont: proc (path: string; size: int; style: FontStyles;
+                  metrics: var FontMetrics): Font =
+    metrics = FontMetrics(ascent: 12, descent: 4, lineHeight: 16)
+    Font(1),
+  closeFont: proc (f: Font) = discard,
+  getFontMetrics: proc (f: Font): FontMetrics =
+    FontMetrics(ascent: 12, descent: 4, lineHeight: 16),
+  measureText: proc (f: Font; text: string): TextExtent =
+    TextExtent(w: text.len * 8, h: 16),
+  drawText: proc (f: Font; x, y: int; text: string;
+                  fg, bg: Color): TextExtent =
+    TextExtent(w: text.len * 8, h: 16))
+
+drawRelays = DrawRelays(
+  fillRect: proc (r: Rect; c: Color) = discard,
+  drawLine: proc (x1, y1, x2, y2: int; color: Color) = discard,
+  drawPoint: proc (x, y: int; color: Color) = discard,
+  loadImage: proc (path: string): Image = Image(0),
+  freeImage: proc (img: Image) = discard,
+  drawImage: proc (img: Image; src, dst: Rect) = discard)
+
+clipboardRelays = ClipboardRelays(
+  getText: proc (): string = "",
+  putText: proc (text: string) = discard)
+
+var m: FontMetrics
+let font = openFont("", 16, m)
+
+var failures = 0
+
+proc check(name: string; cond: bool; detail = "") =
+  if cond:
+    echo "  PASS  ", name
+  else:
+    inc failures
+    echo "  FAIL  ", name, (if detail.len > 0: "  -- " & detail else: "")
+
+const Area = rect(0, 0, 200, 200)   # twelve rows of sixteen pixels
+
+proc newList(count: int): SynEdit =
+  ## A tab list of `count` short names, drawn once so that it has a height.
+  result = createSynEdit(font, defaultTheme())
+  result.lang = langNone
+  var text = ""
+  for i in 0 ..< count:
+    if i > 0: text.add "\n"
+    text.add "tab" & $i
+  result.setText(text)
+  discard result.draw(default(Event), Area, focused = false)
+
+proc frame(ed: var SynEdit; focused: bool) =
+  discard ed.draw(default(Event), Area, focused)
+
+echo "centring a row:"
+
+block: # a list far longer than the panel
+  var ed = newList(100)
+  let rows = ed.span - 1
+  check("the panel has a height to speak of", rows >= 8, $ed.span)
+  ed.centerLine(50)
+  check("a row in the middle of the list lands in the middle of the panel",
+        ed.firstLine.int == 50 - rows div 2,
+        $ed.firstLine & " of " & $ed.span)
+  check("and stays there when the list is drawn unfocused",
+        (ed.frame(focused = false); ed.firstLine.int == 50 - rows div 2),
+        $ed.firstLine)
+
+block: # the ends, where half a panel of blanks would be the naive answer
+  var ed = newList(100)
+  ed.centerLine(0)
+  check("the first row cannot be centred, so the view stays at the top",
+        ed.firstLine.int == 0, $ed.firstLine)
+  ed.centerLine(99)
+  let rows = ed.span - 1
+  check("the last row comes to rest on the bottom row of the panel",
+        ed.firstLine.int == 100 - rows, $ed.firstLine & " of " & $ed.span)
+  check("which is to say the last row is visible",
+        99 >= ed.firstLine.int and 99 < ed.firstLine.int + rows,
+        $ed.firstLine)
+
+block: # a list that fits
+  var ed = newList(5)
+  ed.centerLine(4)
+  check("a list shorter than the panel does not scroll at all",
+        ed.firstLine.int == 0, $ed.firstLine)
+
+block: # never drawn, so it has no middle yet
+  var ed = createSynEdit(font, defaultTheme())
+  ed.setText("a\nb\nc")
+  ed.centerLine(2)
+  check("a panel that has not been drawn is left alone",
+        ed.firstLine.int == 0, $ed.firstLine)
+
+echo "and stepping on from it:"
+
+block: # why the caret is moved along with the view, and not the view alone
+  # The list's caret is what the arrow keys move and what Enter activates, so
+  # a list scrolled to the active tab with its caret left behind reads right
+  # and answers wrong: the first Down goes to the row after whatever the list
+  # was last looking at, somewhere off the top of the panel.
+  var ed = newList(100)
+  ed.gotoLine(1, 0)           # the list was rebuilt; caret back at the top
+  ed.gotoLine(51, 0)          # focim sends it after the active tab (row 50)
+  ed.centerLine(50)
+  let at = ed.firstLine.int
+  check("the caret is on the row that was centred", ed.currentLine == 50,
+        $ed.currentLine)
+  ed.frame(focused = false)
+  ed.frame(focused = true)    # the list gets the focus back
+  check("taking the focus back leaves the view where it was put",
+        ed.firstLine.int == at, $ed.firstLine & " was " & $at)
+  discard ed.draw(Event(kind: KeyDownEvent, key: KeyDown), Area,
+                  focused = true)
+  check("and Down steps to the tab below the active one",
+        ed.currentLine == 51, $ed.currentLine)
+
+block: # and that the view really was moved, not merely left at the top
+  var ed = newList(100)
+  ed.gotoLine(1, 0)
+  ed.frame(focused = false)
+  check("the list starts at the top", ed.firstLine.int == 0, $ed.firstLine)
+  ed.gotoLine(91, 0)
+  ed.centerLine(90)
+  ed.frame(focused = false)
+  let rows = ed.span - 1
+  check("and follows the active tab down to row 90",
+        ed.firstLine.int == 90 - rows div 2, $ed.firstLine)
+
+if failures == 0:
+  echo "PASS"
+else:
+  echo "FAIL ", failures
+  quit 1

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -49,6 +49,9 @@ exec "nim c -r tests/utf8test.nim"
 # The colors a program asks for with escape sequences, and the disappearance
 # of everything else it asks for.
 exec "nim c -r tests/ansitest.nim"
+# And that the tab list goes and shows the tab the editor made current, which
+# is a scroll nothing in the list itself ever asked for.
+exec "nim c -r tests/tablisttest.nim"
 
 # The app, once, with the platform's default backend.
 exec "nim c apps/focim.nim"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -46,6 +46,9 @@ exec "nim c -r tests/filesearchtest.nim"
 # That a rune of more than one byte is one character to every key that steps
 # over it, and that a byte belonging to no rune stands for itself.
 exec "nim c -r tests/utf8test.nim"
+# The colors a program asks for with escape sequences, and the disappearance
+# of everything else it asks for.
+exec "nim c -r tests/ansitest.nim"
 
 # The app, once, with the platform's default backend.
 exec "nim c apps/focim.nim"


### PR DESCRIPTION
The panel showed what a program printed and guessed at its colors from the shape of the lines -- a `+` green, a `-` red, a `warning:` yellow. Anything the program said about color itself came out as `^[[32m` in the middle of the text, so nothing was ever asked to say it.

Measured first, because it decides how much of a terminal this has to become:

  git log -p (color.ui=always)   ^[[m ^[[1m ^[[31m ^[[32m ^[[33m ^[[36m
  nim c --colors:on              ^[[0m ^[[1m ^[[31m ^[[36m
  ls --color=always              ^[[0m ^[[01;34m
  claude -p (pipe *and* pty)     nothing at all

Not one cursor movement between them. So this reads SGR and swallows the rest: no grid, no addressable cursor, no fixed canvas. Interactive full-screen programs are out of scope and stay out -- the same measurement on Claude Code's TUI wants the alternate screen, absolute addressing, mouse reporting and replies to three terminal queries, none of which is reachable without a pty.

widgets/ansi.nim is the parser: bytes in, clean text plus the runs of it that carry a color out. It holds the color across chunks and holds an escape sequence that the end of a chunk cut in half, and gives up on one that grows past anything a real sequence could be -- an `ESC` in a binary file must not swallow the rest of it.

The color goes where the highlighting already goes. `TokenClass` gains the thirteen of the sixteen it did not have; `Green`, `Yellow` and `Red` are the ones it did, and a program that asks for red gets the same red a `-` line does. So `Cell` stays two bytes and no buffer pays for this. Backgrounds are swallowed, and 256-color and 24-bit are quantized to the nearest of the sixteen: an IDE panel wants the theme to win, and an agent's chosen mid-grey would otherwise land on the panel background.

`ansiEnd` is what keeps it. Colors that came with the text are not the highlighter's to guess at, and without a watermark the next keystroke would send the incremental pass back to the start of the buffer and repaint all of it. A chunk that asked for no color is still the highlighter's, which is what keeps a plain `git diff` green and red.

And the reason none of it fires by default: everything here comes out of a pipe, and a program that looks before it colors finds one and turns color off. `colorEnv` says do it anyway, in the three ways that between them cover what gets read in this panel, leaving alone any the user has already set.